### PR TITLE
TA-0000 Updating tests to use the testing-library testId functions

### DIFF
--- a/cypress/integration/tests/office-page.test.js
+++ b/cypress/integration/tests/office-page.test.js
@@ -27,7 +27,7 @@ describe("District Office Page", function () {
             cy.visit(`/offices/district/${this.validOffice.id}`)
             cy.wait("@OfficeRequest")
 
-            cy.get("[data-testid=social-media-section]").within(()=>{
+            cy.findByTestId("social-media-section").within(()=>{
                 cy.get('h4').should('contain', expectedHeaderText)
 
                 cy.get('> span > a > img')
@@ -45,7 +45,7 @@ describe("District Office Page", function () {
             cy.visit(`/offices/district/${this.validOffice.id}`)
             cy.wait("@OfficeRequest")
 
-            cy.get("[data-testid=social-media-section]").should('not.exist')
+            cy.findByTestId("social-media-section").should('not.exist')
         })
     })
 
@@ -56,7 +56,7 @@ describe("District Office Page", function () {
             cy.route("GET", `/api/content/${this.validOffice.id}.json`, "@OfficeResponse").as("OfficeRequest")
             cy.visit(`/offices/district/${this.validOffice.id}`)
             cy.wait("@OfficeRequest")
-            cy.get("[data-testid='office-services-section'")
+            cy.findByTestId("office-services-section")
                 .should('contain', "Some content")
         })
         it("does NOT display the office service section when no information is present", function () {
@@ -65,7 +65,7 @@ describe("District Office Page", function () {
             cy.route("GET", `/api/content/${this.validOffice.id}.json`, "@OfficeResponse").as("OfficeRequest")
             cy.visit(`/offices/district/${this.validOffice.id}`)
             cy.wait("@OfficeRequest")
-            cy.get("[data-testid='office-services-section'").should('not.exist')
+            cy.findByTestId("office-services-section").should('not.exist')
         })
         it("does NOT display the office service section when the information is not in a String data", function () {
             cy.server()
@@ -73,7 +73,7 @@ describe("District Office Page", function () {
             cy.route("GET", `/api/content/${this.validOffice.id}.json`, "@OfficeResponse").as("OfficeRequest")
             cy.visit(`/offices/district/${this.validOffice.id}`)
             cy.wait("@OfficeRequest")
-            cy.get("[data-testid='office-services-section'").should('not.exist')
+            cy.findByTestId("office-services-section").should('not.exist')
         })
     })
 
@@ -86,17 +86,17 @@ describe("District Office Page", function () {
 
             const mainLocation = this.GenericOffice.location[0]
 
-            cy.get("[data-testid=location-info]").within(()=>{
-                cy.get("[data-testid=main-location]").within(()=>{
-                    cy.get("[data-testid='contact card title']").should('have.text', mainLocation.name)
-                    cy.get("[data-testid='contact phone']").should('have.text', mainLocation.phoneNumber)
-                    cy.get("[data-testid='contact fax']").should('have.text', mainLocation.fax)
-                    cy.get("[data-testid='contact email']").should('have.text', mainLocation.email)
-                    cy.get("[data-testid='contact address']").should('contain', mainLocation.streetAddress)
+            cy.findByTestId("location-info").within(()=>{
+                cy.findByTestId("main-location").within(()=>{
+                    cy.findByTestId("contact card title").should('have.text', mainLocation.name)
+                    cy.findByTestId("contact phone").should('have.text', mainLocation.phoneNumber)
+                    cy.findByTestId("contact fax").should('have.text', mainLocation.fax)
+                    cy.findByTestId("contact email").should('have.text', mainLocation.email)
+                    cy.findByTestId("contact address").should('contain', mainLocation.streetAddress)
                         .and('contain', mainLocation.city)
                         .and('contain', mainLocation.state)
                         .and('contain', mainLocation.zipCode)
-                    cy.get("[data-testid='hours of operation']").should('have.text', mainLocation.hoursOfOperation)
+                    cy.findByTestId("hours of operation").should('have.text', mainLocation.hoursOfOperation)
                 })
             })
         })
@@ -109,7 +109,7 @@ describe("District Office Page", function () {
             cy.visit(`/offices/district/${this.validOffice.id}`)
             cy.wait("@OfficeRequest")
 
-            cy.get("[data-testid=location-info]").should('not.exist')
+            cy.findByTestId("location-info").should('not.exist')
         })
 
         it('does NOT display the corresponding section when it does not exist in the office data', function () {
@@ -125,14 +125,14 @@ describe("District Office Page", function () {
             cy.visit(`/offices/district/${this.validOffice.id}`)
             cy.wait("@OfficeRequest")
 
-            cy.get("[data-testid=location-info]").within(()=>{
-                cy.get("[data-testid=main-location]").within(()=>{
-                    cy.get("[data-testid='contact card title']").should('not.have.text')
-                    cy.get("[data-testid='contact phone']").should('not.exist')
-                    cy.get("[data-testid='contact fax']").should('not.exist')
-                    cy.get("[data-testid='contact email']").should('not.exist')
-                    cy.get("[data-testid='contact address']").should('not.exist')
-                    cy.get("[data-testid='hours of operation']").should('not.exist')
+            cy.findByTestId("location-info").within(()=>{
+                cy.findByTestId("main-location").within(()=>{
+                    cy.findByTestId("contact card title").should('not.have.text')
+                    cy.findByTestId("contact phone").should('not.exist')
+                    cy.findByTestId("contact fax").should('not.exist')
+                    cy.findByTestId("contact email").should('not.exist')
+                    cy.findByTestId("contact address").should('not.exist')
+                    cy.findByTestId("hours of operation").should('not.exist')
                 })
             })
         })
@@ -150,12 +150,12 @@ describe("District Office Page", function () {
             cy.visit(`/offices/district/${this.validOffice.id}`)
             cy.wait("@OfficeRequest")
             cy.wait("@NewsRequest")
-            cy.get("[data-testid='news-cards']")
+            cy.findByTestId("news-cards")
                 .find("[data-cy='detail-card-collection-container']")
                 .should('have.length', 3).first()
                 .and('contain',"First Article")
                 .and('contain', "Another example of a news release")
-            cy.get("[data-testid='news-more-button']")
+            cy.findByTestId("news-more-button")
                 .find('a')
                     .should('contain', "View All")
                     .and("has.attr", "href", `/article?office=${this.validOffice.id}&articleCategory=Press release`)
@@ -172,11 +172,11 @@ describe("District Office Page", function () {
             cy.visit(`/offices/district/${this.validOffice.id}`)
             cy.wait("@OfficeRequest")
             cy.wait("@NewsRequest")
-            cy.get("[data-testid='news-cards']")
+            cy.findByTestId("news-cards")
                 .find("[data-cy='detail-card-collection-container']")
                 .should('have.length', 1)
                 .and('contain',"First Article")
-            cy.get("[data-testid='news-more-button']")
+            cy.findByTestId("news-more-button")
                 .find('a')
                     .should('contain', "View All")
                     .and("has.attr", "href", `/article?office=${this.validOffice.id}&articleCategory=Press release`)
@@ -193,8 +193,8 @@ describe("District Office Page", function () {
             cy.visit(`/offices/district/${this.validOffice.id}`)
             cy.wait("@OfficeRequest")
             cy.wait("@NewsRequest")
-            cy.get("[data-testid='news-cards']").should('not.exist')
-            cy.get("[data-testid='news-more-button']").should('not.exist')
+            cy.findByTestId("news-cards").should('not.exist')
+            cy.findByTestId("news-more-button").should('not.exist')
         })
     })
 
@@ -203,11 +203,11 @@ describe("District Office Page", function () {
         cy.server()
         cy.route("GET", `/api/content/${this.validOffice.id}.json`).as("OfficeRequest")
         cy.visit(`/offices/district/${this.validOffice.id}`)
-        cy.get("[data-testid='call-to-action']")
-            .find('a')
-                .should("has.attr", "data-testid", 'button')
-                .should('contain', "Search Nearby")
-                .should("has.attr", "href", '/local-assistance/find')
+        cy.findByTestId("call-to-action").within(() => {
+            cy.findByTestId("button")
+            .should('contain', "Search Nearby")
+            .should("has.attr", "href", '/local-assistance/find')
+        })
     })
 
     it("displays the upcoming events section with events for a district office", function() {
@@ -216,9 +216,9 @@ describe("District Office Page", function () {
         cy.route("GET", "/api/content/search/events.json**", "@EventResults")
         cy.route("GET", `/api/content/${this.validOffice.id}.json`).as("OfficeRequest")
         cy.visit(`/offices/district/${this.validOffice.id}`)
-        cy.get("[data-testid='events']")
+        cy.findByTestId("events")
         cy.get("[data-cy='event result']").should('have.length', 5)
-        cy.get("[data-testid='events-button']").find('a').should("has.attr", "href", '/events/find/')
+        cy.findByTestId("events-button").find('a').should("has.attr", "href", '/events/find/')
     })
 
     describe("Newsletter sign up section", () => {
@@ -228,24 +228,27 @@ describe("District Office Page", function () {
             cy.visit(`/offices/district/${this.validOffice.id}`)
             cy.wait("@OfficeRequest")
 
-            cy.get("[data-testid='office-newsletter']").should("contain", "Sign up for national and local SBA newsletters")
-            cy.get("[data-testid=newsletter-form]").as("form")
-                .should("have.length", 2)
-                .find("[data-testid=button]")
-                .contains("Subscribe")
-            cy.get("@form")
-                .find("[data-testid=caption-text]")
-                .contains("Please enter your zip code to get information about business news and events in your area.")
-            cy.get("@form")
-                .find("[data-testid=newsletter-email-address-container]").within(() => {
-            cy.get("[data-testid=newsletter-email-address-label]").contains("Email address")
-                .get("[data-testid=newsletter-email-address]")
-            })
-            cy.get("@form")
-                .find("[data-testid=newsletter-zip-code-container]").within(() => {
-            cy.get("[data-testid=newsletter-zip-code-label]").contains("Zip code")
-                .get("[data-testid=newsletter-zip-code]")
-          })
+            cy.findByTestId("office-newsletter")
+                .should("contain", "Sign up for national and local SBA newsletters")
+                .within(() => {
+                    cy.findByTestId("newsletter-form").as("form")
+                    .should("have.length", 1)
+                    .findByTestId("button")
+                    .contains("Subscribe")
+                    cy.get("@form")
+                        .findByTestId("caption-text")
+                        .contains("Please enter your zip code to get information about business news and events in your area.")
+                    cy.get("@form")
+                        .findByTestId("newsletter-email-address-container").within(() => {
+                    cy.findByTestId("newsletter-email-address-label").contains("Email address")
+                        .findByTestId("newsletter-email-address")
+                    })
+                    cy.get("@form")
+                        .findByTestId("newsletter-zip-code-container").within(() => {
+                    cy.findByTestId("newsletter-zip-code-label").contains("Zip code")
+                        .findByTestId("newsletter-zip-code")
+                    })
+                })
         })
 
         it("Subscribe button is enabled when e-mail address is valid and zip code field is empty", function() {
@@ -254,11 +257,14 @@ describe("District Office Page", function () {
             cy.visit(`/offices/district/${this.validOffice.id}`)
             cy.wait("@OfficeRequest")
 
-            cy.get("[data-testid=newsletter-email-address]")
-              .type("test4@test4.com")
-            cy.get("[data-testid=newsletter-form]")
-              .find("[data-testid=button]")
-              .should("not.be.disabled")
+            cy.findByTestId("office-newsletter")
+                .within(() => {
+                    cy.findByTestId("newsletter-email-address")
+                    .type("test4@test4.com")
+                    cy.findByTestId("newsletter-form")
+                    .findByTestId("button")
+                    .should("not.be.disabled")
+                })
           })
 
         it("shows error message and disables Subscribe button when e-mail address is invalid", function() {
@@ -267,10 +273,13 @@ describe("District Office Page", function () {
             cy.visit(`/offices/district/${this.validOffice.id}`)
             cy.wait("@OfficeRequest")
 
-            cy.get("[data-testid=newsletter-email-address]").type("test@.com")
-            cy.get("[data-testid=newsletter-zip-code]").type("12345")
-            cy.get("[data-testid=newsletter-form]").contains("Subscribe").should("be.disabled")
-            cy.get("[data-testid=newsletter-email-address-error]").contains("Enter a valid email address")
+            cy.findByTestId("office-newsletter")
+            .within(() => {
+                cy.findByTestId("newsletter-email-address").type("test@.com")
+                cy.findByTestId("newsletter-zip-code").type("12345")
+                cy.findByTestId("newsletter-form").contains("Subscribe").should("be.disabled")
+                cy.findByTestId("newsletter-email-address-error").contains("Enter a valid email address")
+            })
         })
 
         it("shows error message and disables Subscribe button when e-mail address is valid, but zip code is incomplete", function() {
@@ -279,10 +288,13 @@ describe("District Office Page", function () {
             cy.visit(`/offices/district/${this.validOffice.id}`)
             cy.wait("@OfficeRequest")
 
-            cy.get("[data-testid=newsletter-zip-code]").type("3456")
-            cy.get("[data-testid=newsletter-email-address]").type("test4@test4.com")
-            cy.get("[data-testid=newsletter-form]").contains("Subscribe").first().should("be.disabled")
-            cy.get("[data-testid=newsletter-zip-code-error]").contains("Enter a valid zip code")
+            cy.findByTestId("office-newsletter")
+            .within(() => {
+                cy.findByTestId("newsletter-zip-code").type("3456")
+                cy.findByTestId("newsletter-email-address").type("test4@test4.com")
+                cy.findByTestId("newsletter-form").contains("Subscribe").first().should("be.disabled")
+                cy.findByTestId("newsletter-zip-code-error").contains("Enter a valid zip code")
+            })
         })
 
         it("shows the lender match link component", function() {
@@ -291,12 +303,11 @@ describe("District Office Page", function () {
             cy.visit(`/offices/district/${this.validOffice.id}`)
             cy.wait("@OfficeRequest")
 
-            cy.get("[data-testid=office-lender-match]")
+            cy.findByTestId("office-lender-match")
                 .find('a')
                     .should('contain', "Learn More")
                     .should("has.attr", "href", '/lendermatch')
         })
-
     })
 
     describe("hero section", function () {
@@ -318,12 +329,12 @@ describe("District Office Page", function () {
             cy.visit(`/offices/district/${this.validOffice.id}`)
             cy.wait("@OfficeRequest")
 
-            cy.get("[data-testid=hero]").within(()=>{
-                cy.get("[data-testid=title]")
+            cy.findByTestId("hero").within(()=>{
+                cy.findByTestId("title")
                     .should('have.text',expectedTitle)
-                cy.get("[data-testid=message]")
+                cy.findByTestId("message")
                     .should('have.text', expectedSummary)
-                cy.get("[data-testid=button]")
+                cy.findByTestId("button")
                     .contains("Learn More")
                     .and('has.attr', "href", expectedButtonUrl)
                 cy.get("div")
@@ -340,8 +351,8 @@ describe("District Office Page", function () {
             cy.visit(`/offices/district/${this.validOffice.id}`)
             cy.wait("@OfficeRequest")
 
-            cy.get("[data-testid=hero]").within(()=>{
-                cy.get("[data-testid=button]").should('not.exist')
+            cy.findByTestId("hero").within(()=>{
+                cy.findByTestId("button").should('not.exist')
             })
         })
 
@@ -357,10 +368,10 @@ describe("District Office Page", function () {
             cy.visit(`/offices/district/${this.validOffice.id}`)
             cy.wait("@OfficeRequest")
 
-            cy.get("[data-testid=hero]").within(()=>{
-                cy.get("[data-testid=title]")
+            cy.findByTestId("hero").within(()=>{
+                cy.findByTestId("title")
                     .should('have.text',expectedTitle)
-                cy.get("[data-testid=message]")
+                cy.findByTestId("message")
                     .should('have.text', expectedSummary)
             })
         })
@@ -393,11 +404,11 @@ describe("District Office Page", function () {
             cy.wait("@Leader2")
             cy.wait("@Leader3")
 
-            cy.get("[data-testid='office-leadership']").within(() =>{
-                cy.get('[data-testid=authorCard]').should('have.length', 3)
-                cy.get('[data-testid=authorCard]').eq(0).should('contain', "Leader One")
-                cy.get('[data-testid=authorCard]').eq(1).should('contain', "Leader Two")
-                cy.get('[data-testid=authorCard]').eq(2).should('contain', "Leader Three")
+            cy.findByTestId("office-leadership").within(() =>{
+                cy.findAllByTestId("authorCard").should('have.length', 3)
+                cy.findAllByTestId("authorCard").eq(0).should('contain', "Leader One")
+                cy.findAllByTestId("authorCard").eq(1).should('contain', "Leader Two")
+                cy.findAllByTestId("authorCard").eq(2).should('contain', "Leader Three")
             })
         })
 
@@ -410,7 +421,7 @@ describe("District Office Page", function () {
             cy.visit(`/offices/district/${this.validOffice.id}`)
             cy.wait("@OfficeRequest")
 
-            cy.get("[data-testid=office-leadership]").should('not.exist')
+            cy.findByTestId("office-leadership").should('not.exist')
         })
 
         it("only displays 3 leaders even if more are listed", function () {
@@ -432,8 +443,8 @@ describe("District Office Page", function () {
             cy.wait("@Leader2")
             cy.wait("@Leader3")
 
-            cy.get("[data-testid='office-leadership']").within(() =>{
-                cy.get('[data-testid=authorCard]').should('have.length', 3)
+            cy.findByTestId("office-leadership").within(() =>{
+                cy.findAllByTestId("authorCard").should('have.length', 3)
             })
         })
 
@@ -451,8 +462,8 @@ describe("District Office Page", function () {
             cy.wait("@OfficeRequest")
             cy.wait("@Leader1")
 
-            cy.get("[data-testid='office-leadership']").within(() =>{
-                cy.get('[data-testid=authorCard]').should('have.length', 1)
+            cy.findByTestId("office-leadership").within(() =>{
+                cy.findByTestId("authorCard").should('have.length', 1)
             })
         })
 
@@ -479,8 +490,8 @@ describe("District Office Page", function () {
             cy.wait("@Leader1")
             cy.wait("@Leader2")
 
-            cy.get("[data-testid='office-leadership']").within(() =>{
-                cy.get('[data-testid=authorCard]').should('have.length', 2)
+            cy.findByTestId("office-leadership").within(() =>{
+                cy.findAllByTestId("authorCard").should('have.length', 2)
             })
         })
     })

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -23,3 +23,7 @@
 //
 // -- This is will overwrite an existing command --
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
+//
+//
+// -- Adding DOM Testing library commands to cypress
+import '@testing-library/cypress/add-commands'

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,15 +4,30 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@babel/runtime": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.0.tgz",
+      "integrity": "sha512-89eSBLJsxNxOERC0Op4vd+0Bqm6wRMqMbFtV3i0/fbaWw/mJ8Q3eBvgX0G4SyrOOLCtbu98HspF8o09MRT+KzQ==",
+      "requires": {
+        "regenerator-runtime": "^0.13.2"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.13.3",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+          "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
+        }
+      }
+    },
     "@cypress/listr-verbose-renderer": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@cypress/listr-verbose-renderer/-/listr-verbose-renderer-0.4.1.tgz",
       "integrity": "sha1-p3SS9LEdzHxEajSz4ochr9M8ZCo=",
       "requires": {
-        "chalk": "1.1.3",
-        "cli-cursor": "1.0.2",
-        "date-fns": "1.30.1",
-        "figures": "1.7.0"
+        "chalk": "^1.1.3",
+        "cli-cursor": "^1.0.2",
+        "date-fns": "^1.27.2",
+        "figures": "^1.7.0"
       },
       "dependencies": {
         "chalk": {
@@ -20,11 +35,11 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
         "supports-color": {
@@ -39,19 +54,122 @@
       "resolved": "https://registry.npmjs.org/@cypress/xvfb/-/xvfb-1.2.4.tgz",
       "integrity": "sha512-skbBzPggOVYCbnGgV+0dmBdW/s77ZkAOXIC1knS8NagwDjBrNC1LuXtQJeiN6l+m7lzmHtaoUw/ctJKdqkG57Q==",
       "requires": {
-        "debug": "3.1.0",
-        "lodash.once": "4.1.1"
+        "debug": "^3.1.0",
+        "lodash.once": "^4.1.1"
       }
+    },
+    "@jest/types": {
+      "version": "24.9.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-24.9.0.tgz",
+      "integrity": "sha512-XKK7ze1apu5JWQ5eZjHITP66AX+QsLlbaJRBGYr8pNzwcAE2JVkwnf0yqjHTsDRcjR0mujy/NmZMXw5kl+kGBw==",
+      "requires": {
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^1.1.1",
+        "@types/yargs": "^13.0.0"
+      }
+    },
+    "@sheerun/mutationobserver-shim": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.2.tgz",
+      "integrity": "sha512-vTCdPp/T/Q3oSqwHmZ5Kpa9oI7iLtGl3RQaA/NyLHikvcrPxACkkKVr/XzkSPJWXHRhKGzVvb0urJsbMlRxi1Q=="
+    },
+    "@testing-library/cypress": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/cypress/-/cypress-5.0.0.tgz",
+      "integrity": "sha512-+koZObqHbgrqsZr6knbKLfGsuT2YoNIX0H60iMlMHQOvuIvZriyHKIDQMAxnCPn3nPKjIepZnUVAAz+WMHIwLQ==",
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "@testing-library/dom": "^6.0.0",
+        "@types/testing-library__cypress": "^4.1.0"
+      }
+    },
+    "@testing-library/dom": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-6.2.0.tgz",
+      "integrity": "sha512-YaaoAIDTNV8AfC19XLa6KNeBB5KuSxWYPrgYN1vBu1i+czQlfWJSCS0A3yd2V3BUH9di9C1BD+7OoyVBpZCh2Q==",
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "@sheerun/mutationobserver-shim": "^0.3.2",
+        "@types/testing-library__dom": "^6.0.0",
+        "aria-query": "3.0.0",
+        "pretty-format": "^24.8.0",
+        "wait-for-expect": "^1.3.0"
+      }
+    },
+    "@types/istanbul-lib-coverage": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
+      "integrity": "sha512-hRJD2ahnnpLgsj6KWMYSrmXkM3rm2Dl1qkx6IOFD5FnuNPXJIG5L0dhgKXCYTRMGzU4n0wImQ/xfmRc4POUFlg=="
+    },
+    "@types/istanbul-lib-report": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-1.1.1.tgz",
+      "integrity": "sha512-3BUTyMzbZa2DtDI2BkERNC6jJw2Mr2Y0oGI7mRxYNBPxppbtEK1F66u3bKwU2g+wxwWI7PAoRpJnOY1grJqzHg==",
+      "requires": {
+        "@types/istanbul-lib-coverage": "*"
+      }
+    },
+    "@types/istanbul-reports": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.1.tgz",
+      "integrity": "sha512-UpYjBi8xefVChsCoBpKShdxTllC9pwISirfoZsUa2AAdQg/Jd2KQGtSbw+ya7GPo7x/wAPlH6JBhKhAsXUEZNA==",
+      "requires": {
+        "@types/istanbul-lib-coverage": "*",
+        "@types/istanbul-lib-report": "*"
+      }
+    },
+    "@types/jquery": {
+      "version": "3.3.31",
+      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.3.31.tgz",
+      "integrity": "sha512-Lz4BAJihoFw5nRzKvg4nawXPzutkv7wmfQ5121avptaSIXlDNJCUuxZxX/G+9EVidZGuO0UBlk+YjKbwRKJigg==",
+      "requires": {
+        "@types/sizzle": "*"
+      }
+    },
+    "@types/sizzle": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.2.tgz",
+      "integrity": "sha512-7EJYyKTL7tFR8+gDbB6Wwz/arpGa0Mywk1TJbNzKzHtzbwVmY4HR9WqS5VV7dsBUKQmPNr192jHr/VpBluj/hg=="
+    },
+    "@types/testing-library__cypress": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@types/testing-library__cypress/-/testing-library__cypress-4.2.0.tgz",
+      "integrity": "sha512-e3Z7zLHGH+n5B0kfYEW5GoO55J2nCNSFnacg0wnXkMOpBKvZVXB5GtRVCWQF2+I2vnCahu8dB96AmLh7dnw5TA==",
+      "requires": {
+        "@types/jquery": "*",
+        "@types/testing-library__dom": "*"
+      }
+    },
+    "@types/testing-library__dom": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/testing-library__dom/-/testing-library__dom-6.0.3.tgz",
+      "integrity": "sha512-NCjixGZ6iubYpe63YKYJy/bDkPp+HD8fbi+0iXcaYhsYjQhoa7IfFz/WcaCRZJnKSi63c9GSK9pZi/Y8/gTvFA==",
+      "requires": {
+        "pretty-format": "^24.3.0"
+      }
+    },
+    "@types/yargs": {
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.2.tgz",
+      "integrity": "sha512-lwwgizwk/bIIU+3ELORkyuOgDjCh7zuWDFqRtPPhhVgq9N1F7CvLNKg1TX4f2duwtKQ0p044Au9r1PLIXHrIzQ==",
+      "requires": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "@types/yargs-parser": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-13.1.0.tgz",
+      "integrity": "sha512-gCubfBUZ6KxzoibJ+SCUc/57Ms1jz5NjHe4+dI2krNmU5zCPAphyLJYyTOg06ueIyfj+SaCUqmzun7ImlxDcKg=="
     },
     "ajv": {
       "version": "6.10.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
       "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
       "requires": {
-        "fast-deep-equal": "2.0.1",
-        "fast-json-stable-stringify": "2.0.0",
-        "json-schema-traverse": "0.4.1",
-        "uri-js": "4.2.2"
+        "fast-deep-equal": "^2.0.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
       }
     },
     "ansi-escapes": {
@@ -74,12 +192,21 @@
       "resolved": "https://registry.npmjs.org/arch/-/arch-2.1.1.tgz",
       "integrity": "sha512-BLM56aPo9vLLFVa8+/+pJLnrZ7QGGTVHWsCwieAWT9o9K8UeGaQbzZbGoabWLOo2ksBCztoXdqBZBplqLDDCSg=="
     },
+    "aria-query": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-3.0.0.tgz",
+      "integrity": "sha1-ZbP8wcoRVajJrmTW7uKX8V1RM8w=",
+      "requires": {
+        "ast-types-flow": "0.0.7",
+        "commander": "^2.11.0"
+      }
+    },
     "asn1": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-      "integrity": "sha1-jSR136tVO7M+d7VOWeiAu4ziMTY=",
+      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
       "requires": {
-        "safer-buffer": "2.1.2"
+        "safer-buffer": "~2.1.0"
       }
     },
     "assert-plus": {
@@ -87,12 +214,17 @@
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
+    "ast-types-flow": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
+      "integrity": "sha1-9wtzXGvKGlycItmCw+Oef+ujva0="
+    },
     "async": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
       "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
       "requires": {
-        "lodash": "4.17.11"
+        "lodash": "^4.17.10"
       },
       "dependencies": {
         "lodash": {
@@ -115,15 +247,15 @@
     "aws4": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-      "integrity": "sha1-8OAD2cqef1nHpQiUXXsu+aBKVC8="
+      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
     },
     "babel-runtime": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "requires": {
-        "core-js": "2.5.7",
-        "regenerator-runtime": "0.11.1"
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
       }
     },
     "balanced-match": {
@@ -136,7 +268,7 @@
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "requires": {
-        "tweetnacl": "0.14.5"
+        "tweetnacl": "^0.14.3"
       }
     },
     "bluebird": {
@@ -147,16 +279,16 @@
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
     "browser-stdout": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
-      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw=="
+      "integrity": "sha1-uqVZ7hTO1zRSIputcyZGfGH6vWA="
     },
     "buffer-crc32": {
       "version": "0.2.13",
@@ -171,9 +303,9 @@
     "cachedir": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/cachedir/-/cachedir-1.3.0.tgz",
-      "integrity": "sha512-O1ji32oyON9laVPJL1IZ5bmwd2cB46VfpxkDequezH+15FDzzVddEyrGEeX4WusDSqKxdyFdDQDEG1yo1GoWkg==",
+      "integrity": "sha1-XgGSi/LZW17dlLCUIYgkZ0Dg28Q=",
       "requires": {
-        "os-homedir": "1.0.2"
+        "os-homedir": "^1.0.1"
       }
     },
     "camelcase": {
@@ -189,19 +321,19 @@
     "chalk": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-      "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+      "integrity": "sha1-GMSasWoDe26wFSzIPjRxM4IVtm4=",
       "requires": {
-        "ansi-styles": "3.2.1",
-        "escape-string-regexp": "1.0.5",
-        "supports-color": "5.4.0"
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
       },
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
           "requires": {
-            "color-convert": "1.9.2"
+            "color-convert": "^1.9.0"
           }
         },
         "supports-color": {
@@ -209,7 +341,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -222,14 +354,14 @@
     "ci-info": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
-      "integrity": "sha1-LKINu5zrMtRSSmgzAzE/AwSx5Jc="
+      "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A=="
     },
     "cli-cursor": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
       "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
       "requires": {
-        "restore-cursor": "1.0.1"
+        "restore-cursor": "^1.0.1"
       }
     },
     "cli-spinners": {
@@ -243,17 +375,17 @@
       "integrity": "sha1-nxXPuwcFAFNpIWxiasfQWrkN1XQ=",
       "requires": {
         "slice-ansi": "0.0.4",
-        "string-width": "1.0.2"
+        "string-width": "^1.0.1"
       }
     },
     "cliui": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
-      "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+      "integrity": "sha1-NIQi2+gtgAswIu709qwQvy5NG0k=",
       "requires": {
-        "string-width": "2.1.1",
-        "strip-ansi": "4.0.0",
-        "wrap-ansi": "2.1.0"
+        "string-width": "^2.1.1",
+        "strip-ansi": "^4.0.0",
+        "wrap-ansi": "^2.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -269,10 +401,10 @@
         "string-width": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           }
         },
         "strip-ansi": {
@@ -280,7 +412,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -308,7 +440,7 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "requires": {
-        "delayed-stream": "1.0.0"
+        "delayed-stream": "~1.0.0"
       }
     },
     "commander": {
@@ -331,10 +463,10 @@
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "requires": {
-        "buffer-from": "1.1.1",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.6",
-        "typedarray": "0.0.6"
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
       }
     },
     "core-js": {
@@ -350,13 +482,13 @@
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "integrity": "sha1-Sl7Hxk364iw6FBJNus3uhG2Ay8Q=",
       "requires": {
-        "nice-try": "1.0.4",
-        "path-key": "2.0.1",
-        "semver": "5.5.0",
-        "shebang-command": "1.2.0",
-        "which": "1.3.1"
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
       }
     },
     "cypress": {
@@ -402,7 +534,7 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "requires": {
-            "color-convert": "1.9.2"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -410,9 +542,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.5.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "debug": {
@@ -420,7 +552,7 @@
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
           "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "requires": {
-            "ms": "2.1.2"
+            "ms": "^2.1.1"
           }
         },
         "glob": {
@@ -428,12 +560,12 @@
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
           "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "lodash": {
@@ -453,23 +585,23 @@
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "date-fns": {
       "version": "1.30.1",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
-      "integrity": "sha1-LnG/CxGRU9u0zE6I2epaz7UNwFw="
+      "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw=="
     },
     "dateformat": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
-      "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q=="
+      "integrity": "sha1-puN0maTZqc+F71hyBE1ikByYia4="
     },
     "debug": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
       "requires": {
         "ms": "2.0.0"
       }
@@ -487,15 +619,15 @@
     "diff": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
+      "integrity": "sha1-gAwN0eCov7yVg1wgKtIg/jF+WhI="
     },
     "ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "requires": {
-        "jsbn": "0.1.1",
-        "safer-buffer": "2.1.2"
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
       }
     },
     "elegant-spinner": {
@@ -506,9 +638,9 @@
     "end-of-stream": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+      "integrity": "sha1-7SljTRm6ukY7bOa4CjchPqtx7EM=",
       "requires": {
-        "once": "1.4.0"
+        "once": "^1.4.0"
       }
     },
     "escape-string-regexp": {
@@ -519,23 +651,23 @@
     "execa": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
-      "integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
+      "integrity": "sha1-/0Vqj1P5D47MxxqW0Rvfx/CCy1A=",
       "requires": {
-        "cross-spawn": "6.0.5",
-        "get-stream": "3.0.0",
-        "is-stream": "1.1.0",
-        "npm-run-path": "2.0.2",
-        "p-finally": "1.0.0",
-        "signal-exit": "3.0.2",
-        "strip-eof": "1.0.0"
+        "cross-spawn": "^6.0.0",
+        "get-stream": "^3.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
       }
     },
     "executable": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/executable/-/executable-4.1.1.tgz",
-      "integrity": "sha512-8iA79xD3uAch729dUG8xaaBBFGaEa0wdD2VkYLFHwlqosEj/jT66AzcreRDSgV7ehnNLBW2WR5jIXwGKjVdTLg==",
+      "integrity": "sha1-QVMr/zYdPlevTXY7cFgtsY9dEzw=",
       "requires": {
-        "pify": "2.3.0"
+        "pify": "^2.2.0"
       }
     },
     "exit-hook": {
@@ -546,7 +678,7 @@
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+      "integrity": "sha1-+LETa0Bx+9jrFAr/hYsQGewpFfo="
     },
     "extract-zip": {
       "version": "1.6.7",
@@ -562,7 +694,7 @@
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "requires": {
             "ms": "2.0.0"
           }
@@ -572,7 +704,7 @@
           "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
           "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
           "requires": {
-            "fd-slicer": "1.0.1"
+            "fd-slicer": "~1.0.1"
           }
         }
       }
@@ -597,7 +729,7 @@
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
       "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
       "requires": {
-        "pend": "1.2.0"
+        "pend": "~1.2.0"
       }
     },
     "figures": {
@@ -605,8 +737,8 @@
       "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
       "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
       "requires": {
-        "escape-string-regexp": "1.0.5",
-        "object-assign": "4.1.1"
+        "escape-string-regexp": "^1.0.5",
+        "object-assign": "^4.1.0"
       }
     },
     "find-up": {
@@ -614,7 +746,7 @@
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
       "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
       "requires": {
-        "locate-path": "2.0.0"
+        "locate-path": "^2.0.0"
       }
     },
     "forever-agent": {
@@ -625,11 +757,11 @@
     "form-data": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-      "integrity": "sha1-3M5SwF9kTymManq5Nr1yTO/786Y=",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
       "requires": {
-        "asynckit": "0.4.0",
-        "combined-stream": "1.0.8",
-        "mime-types": "2.1.24"
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
       }
     },
     "fs-extra": {
@@ -637,9 +769,9 @@
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
       "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
       "requires": {
-        "graceful-fs": "4.1.11",
-        "jsonfile": "4.0.0",
-        "universalify": "0.1.2"
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
       }
     },
     "fs.realpath": {
@@ -650,12 +782,12 @@
     "fsu": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/fsu/-/fsu-1.1.1.tgz",
-      "integrity": "sha512-xQVsnjJ/5pQtcKh+KjUoZGzVWn4uNkchxTF6Lwjr4Gf7nQr8fmUfhKJ62zE77+xQg9xnxi5KUps7XGs+VC986A=="
+      "integrity": "sha1-vTbTV5kHxZ2FslenW4NqqeDDGDQ="
     },
     "get-caller-file": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
-      "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
+      "integrity": "sha1-+Xj6TJDR3+f/LWvtoqUV5xO9z0o="
     },
     "get-stream": {
       "version": "3.0.0",
@@ -675,20 +807,20 @@
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "global-dirs": {
@@ -696,7 +828,7 @@
       "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
       "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
       "requires": {
-        "ini": "1.3.5"
+        "ini": "^1.3.4"
       }
     },
     "graceful-fs": {
@@ -707,7 +839,7 @@
     "growl": {
       "version": "1.10.5",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
-      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA=="
+      "integrity": "sha1-8nNdwig2dPpnR4sQGBBZNVw2nl4="
     },
     "har-schema": {
       "version": "2.0.0",
@@ -719,8 +851,8 @@
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
       "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
       "requires": {
-        "ajv": "6.10.0",
-        "har-schema": "2.0.0"
+        "ajv": "^6.5.5",
+        "har-schema": "^2.0.0"
       }
     },
     "has-ansi": {
@@ -728,7 +860,7 @@
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "has-flag": {
@@ -746,9 +878,9 @@
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "requires": {
-        "assert-plus": "1.0.0",
-        "jsprim": "1.4.1",
-        "sshpk": "1.16.1"
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
       }
     },
     "indent-string": {
@@ -756,7 +888,7 @@
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
       "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
       "requires": {
-        "repeating": "2.0.1"
+        "repeating": "^2.0.0"
       }
     },
     "inflight": {
@@ -764,8 +896,8 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -776,7 +908,7 @@
     "ini": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+      "integrity": "sha1-7uJfVtscnsYIXgwid4CD9Zar+Sc="
     },
     "invert-kv": {
       "version": "1.0.0",
@@ -788,7 +920,7 @@
       "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
       "integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
       "requires": {
-        "ci-info": "1.6.0"
+        "ci-info": "^1.5.0"
       }
     },
     "is-finite": {
@@ -796,7 +928,7 @@
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "is-fullwidth-code-point": {
@@ -804,7 +936,7 @@
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "is-installed-globally": {
@@ -812,8 +944,8 @@
       "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
       "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
       "requires": {
-        "global-dirs": "0.1.1",
-        "is-path-inside": "1.0.1"
+        "global-dirs": "^0.1.0",
+        "is-path-inside": "^1.0.0"
       }
     },
     "is-path-inside": {
@@ -821,7 +953,7 @@
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
       "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "requires": {
-        "path-is-inside": "1.0.2"
+        "path-is-inside": "^1.0.1"
       }
     },
     "is-promise": {
@@ -857,7 +989,7 @@
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      "integrity": "sha1-GSA/tZmR35jjoocFDUZHzerzJJk="
     },
     "jsbn": {
       "version": "0.1.1",
@@ -884,7 +1016,7 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "requires": {
-        "graceful-fs": "4.1.11"
+        "graceful-fs": "^4.1.6"
       }
     },
     "jsprim": {
@@ -908,7 +1040,7 @@
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
       "requires": {
-        "invert-kv": "1.0.0"
+        "invert-kv": "^1.0.0"
       }
     },
     "listr": {
@@ -916,22 +1048,22 @@
       "resolved": "https://registry.npmjs.org/listr/-/listr-0.12.0.tgz",
       "integrity": "sha1-a84sD1YD+klYDqF81qAMwOX6RRo=",
       "requires": {
-        "chalk": "1.1.3",
-        "cli-truncate": "0.2.1",
-        "figures": "1.7.0",
-        "indent-string": "2.1.0",
-        "is-promise": "2.1.0",
-        "is-stream": "1.1.0",
-        "listr-silent-renderer": "1.1.1",
-        "listr-update-renderer": "0.2.0",
-        "listr-verbose-renderer": "0.4.1",
-        "log-symbols": "1.0.2",
-        "log-update": "1.0.2",
-        "ora": "0.2.3",
-        "p-map": "1.2.0",
-        "rxjs": "5.5.12",
-        "stream-to-observable": "0.1.0",
-        "strip-ansi": "3.0.1"
+        "chalk": "^1.1.3",
+        "cli-truncate": "^0.2.1",
+        "figures": "^1.7.0",
+        "indent-string": "^2.1.0",
+        "is-promise": "^2.1.0",
+        "is-stream": "^1.1.0",
+        "listr-silent-renderer": "^1.1.1",
+        "listr-update-renderer": "^0.2.0",
+        "listr-verbose-renderer": "^0.4.0",
+        "log-symbols": "^1.0.2",
+        "log-update": "^1.0.2",
+        "ora": "^0.2.3",
+        "p-map": "^1.1.1",
+        "rxjs": "^5.0.0-beta.11",
+        "stream-to-observable": "^0.1.0",
+        "strip-ansi": "^3.0.1"
       },
       "dependencies": {
         "chalk": {
@@ -939,11 +1071,11 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
         "log-symbols": {
@@ -951,7 +1083,7 @@
           "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
           "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
           "requires": {
-            "chalk": "1.1.3"
+            "chalk": "^1.0.0"
           }
         },
         "supports-color": {
@@ -971,14 +1103,14 @@
       "resolved": "https://registry.npmjs.org/listr-update-renderer/-/listr-update-renderer-0.2.0.tgz",
       "integrity": "sha1-yoDhd5tOcCZoB+ju0a1qvjmFUPk=",
       "requires": {
-        "chalk": "1.1.3",
-        "cli-truncate": "0.2.1",
-        "elegant-spinner": "1.0.1",
-        "figures": "1.7.0",
-        "indent-string": "3.2.0",
-        "log-symbols": "1.0.2",
-        "log-update": "1.0.2",
-        "strip-ansi": "3.0.1"
+        "chalk": "^1.1.3",
+        "cli-truncate": "^0.2.1",
+        "elegant-spinner": "^1.0.1",
+        "figures": "^1.7.0",
+        "indent-string": "^3.0.0",
+        "log-symbols": "^1.0.2",
+        "log-update": "^1.0.2",
+        "strip-ansi": "^3.0.1"
       },
       "dependencies": {
         "chalk": {
@@ -986,11 +1118,11 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
         "indent-string": {
@@ -1003,7 +1135,7 @@
           "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
           "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
           "requires": {
-            "chalk": "1.1.3"
+            "chalk": "^1.0.0"
           }
         },
         "supports-color": {
@@ -1018,10 +1150,10 @@
       "resolved": "https://registry.npmjs.org/listr-verbose-renderer/-/listr-verbose-renderer-0.4.1.tgz",
       "integrity": "sha1-ggb0z21S3cWCfl/RSYng6WWTOjU=",
       "requires": {
-        "chalk": "1.1.3",
-        "cli-cursor": "1.0.2",
-        "date-fns": "1.30.1",
-        "figures": "1.7.0"
+        "chalk": "^1.1.3",
+        "cli-cursor": "^1.0.2",
+        "date-fns": "^1.27.2",
+        "figures": "^1.7.0"
       },
       "dependencies": {
         "chalk": {
@@ -1029,11 +1161,11 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
         "supports-color": {
@@ -1048,8 +1180,8 @@
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "requires": {
-        "p-locate": "2.0.0",
-        "path-exists": "3.0.0"
+        "p-locate": "^2.0.0",
+        "path-exists": "^3.0.0"
       }
     },
     "lodash": {
@@ -1060,7 +1192,7 @@
     "lodash.isfunction": {
       "version": "3.0.9",
       "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz",
-      "integrity": "sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw=="
+      "integrity": "sha1-Bt4l302zJ6yTGYHRvbBn5a9o0FE="
     },
     "lodash.once": {
       "version": "4.1.1",
@@ -1070,9 +1202,9 @@
     "log-symbols": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
-      "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+      "integrity": "sha1-V0Dhxdbw39pK2TI7UzIQfva0xAo=",
       "requires": {
-        "chalk": "2.4.1"
+        "chalk": "^2.0.1"
       }
     },
     "log-update": {
@@ -1080,16 +1212,16 @@
       "resolved": "https://registry.npmjs.org/log-update/-/log-update-1.0.2.tgz",
       "integrity": "sha1-GZKfZMQJPS0ucHWh2tivWcKWuNE=",
       "requires": {
-        "ansi-escapes": "1.4.0",
-        "cli-cursor": "1.0.2"
+        "ansi-escapes": "^1.0.0",
+        "cli-cursor": "^1.0.2"
       }
     },
     "loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "integrity": "sha1-ce5R+nvkyuwaY4OffmgtgTLTDK8=",
       "requires": {
-        "js-tokens": "4.0.0"
+        "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
     "lru-cache": {
@@ -1097,16 +1229,16 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
       "integrity": "sha1-i75Q6oW+1ZvJ4z3KuCNe6bz0Q80=",
       "requires": {
-        "pseudomap": "1.0.2",
-        "yallist": "2.1.2"
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
       }
     },
     "map-age-cleaner": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
-      "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
+      "integrity": "sha1-fVg6cwZDTAVf5HSw9FB45uG0uSo=",
       "requires": {
-        "p-defer": "1.0.0"
+        "p-defer": "^1.0.0"
       }
     },
     "mem": {
@@ -1114,7 +1246,7 @@
       "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
       "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
       "requires": {
-        "mimic-fn": "1.2.0"
+        "mimic-fn": "^1.0.0"
       }
     },
     "mime-db": {
@@ -1133,14 +1265,14 @@
     "mimic-fn": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
+      "integrity": "sha1-ggyGo5M0ZA6ZUWkovQP8qIBX0CI="
     },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "requires": {
-        "brace-expansion": "1.1.11"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -1166,7 +1298,7 @@
     "mocha": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
-      "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
+      "integrity": "sha1-bYrlCPWRZ/lA8rWzxKYSrlDJCuY=",
       "requires": {
         "browser-stdout": "1.3.1",
         "commander": "2.15.1",
@@ -1184,7 +1316,7 @@
         "commander": {
           "version": "2.15.1",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-          "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
+          "integrity": "sha1-30boZ9D8Kuxmo0ZitAapzK//Ww8="
         },
         "minimist": {
           "version": "0.0.8",
@@ -1202,9 +1334,9 @@
         "supports-color": {
           "version": "5.4.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "integrity": "sha1-HGszdALCE3YF7+GfEP7DkPb6q1Q=",
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -1212,16 +1344,16 @@
     "mochawesome": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/mochawesome/-/mochawesome-3.1.1.tgz",
-      "integrity": "sha512-UzRr6kRIw9UCsJIMuDZh92VKF+3Iu6KQpKHF0lahzmJMUDUjKA4i/7avEURl4a9vPOZWYQCiPRioAAeIpynPpg==",
+      "integrity": "sha1-EG22y3Xcb2JrzFWch1LJnvE17FM=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "chalk": "2.4.1",
-        "diff": "3.5.0",
-        "json-stringify-safe": "5.0.1",
-        "lodash": "4.17.4",
-        "mochawesome-report-generator": "3.1.5",
-        "strip-ansi": "4.0.0",
-        "uuid": "3.3.2"
+        "babel-runtime": "^6.20.0",
+        "chalk": "^2.3.0",
+        "diff": "^3.4.0",
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.17.3",
+        "mochawesome-report-generator": "^3.0.1",
+        "strip-ansi": "^4.0.0",
+        "uuid": "^3.0.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -1234,7 +1366,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -1244,10 +1376,10 @@
       "resolved": "https://registry.npmjs.org/mochawesome-merge/-/mochawesome-merge-1.0.5.tgz",
       "integrity": "sha512-U+JoeiQ0nVAIra5kL940vj252rYscPD2iLo94qE04cxodDUnDyjFM/7CfUVpLwiz1lc5dVuQJ5BGdLahmraZMA==",
       "requires": {
-        "fs-extra": "7.0.1",
-        "minimatch": "3.0.4",
-        "uuid": "3.3.2",
-        "yargs": "12.0.5"
+        "fs-extra": "^7.0.1",
+        "minimatch": "^3.0.4",
+        "uuid": "^3.3.2",
+        "yargs": "^12.0.5"
       },
       "dependencies": {
         "ansi-regex": {
@@ -1258,52 +1390,52 @@
         "camelcase": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
-          "integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA=="
+          "integrity": "sha1-AylVJ9WL081Kp1Nj81sujZe+L0I="
         },
         "execa": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
-          "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+          "integrity": "sha1-xiNqW7TfbW8V6I5/AXeYIWdJ3dg=",
           "requires": {
-            "cross-spawn": "6.0.5",
-            "get-stream": "4.1.0",
-            "is-stream": "1.1.0",
-            "npm-run-path": "2.0.2",
-            "p-finally": "1.0.0",
-            "signal-exit": "3.0.2",
-            "strip-eof": "1.0.0"
+            "cross-spawn": "^6.0.0",
+            "get-stream": "^4.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
           }
         },
         "find-up": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
           "requires": {
-            "locate-path": "3.0.0"
+            "locate-path": "^3.0.0"
           }
         },
         "fs-extra": {
           "version": "7.0.1",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-          "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+          "integrity": "sha1-TxicRKoSO4lfcigE9V6iPq3DSOk=",
           "requires": {
-            "graceful-fs": "4.1.11",
-            "jsonfile": "4.0.0",
-            "universalify": "0.1.2"
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
           }
         },
         "get-stream": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+          "integrity": "sha1-wbJVV189wh1Zv8ec09K0axw6VLU=",
           "requires": {
-            "pump": "3.0.0"
+            "pump": "^3.0.0"
           }
         },
         "invert-kv": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
-          "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA=="
+          "integrity": "sha1-c5P1r6Weyf9fZ6J2INEcIm4+7AI="
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
@@ -1315,24 +1447,24 @@
           "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
           "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
           "requires": {
-            "graceful-fs": "4.1.11"
+            "graceful-fs": "^4.1.6"
           }
         },
         "lcid": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
-          "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
+          "integrity": "sha1-bvXS32DlL4LrIopMNz6NHzlyU88=",
           "requires": {
-            "invert-kv": "2.0.0"
+            "invert-kv": "^2.0.0"
           }
         },
         "locate-path": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
           "requires": {
-            "p-locate": "3.0.0",
-            "path-exists": "3.0.0"
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
           }
         },
         "mem": {
@@ -1340,49 +1472,49 @@
           "resolved": "https://registry.npmjs.org/mem/-/mem-4.1.0.tgz",
           "integrity": "sha512-I5u6Q1x7wxO0kdOpYBB28xueHADYps5uty/zg936CiG8NTe5sJL8EjrCuLneuDW3PlMdZBGDIn8BirEVdovZvg==",
           "requires": {
-            "map-age-cleaner": "0.1.3",
-            "mimic-fn": "1.2.0",
-            "p-is-promise": "2.0.0"
+            "map-age-cleaner": "^0.1.1",
+            "mimic-fn": "^1.0.0",
+            "p-is-promise": "^2.0.0"
           }
         },
         "os-locale": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
-          "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
+          "integrity": "sha1-qAKm7hfyTBBIOrmTVxnO9O0Wvxo=",
           "requires": {
-            "execa": "1.0.0",
-            "lcid": "2.0.0",
-            "mem": "4.1.0"
+            "execa": "^1.0.0",
+            "lcid": "^2.0.0",
+            "mem": "^4.0.0"
           }
         },
         "p-limit": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.1.0.tgz",
-          "integrity": "sha512-NhURkNcrVB+8hNfLuysU8enY5xn2KXphsHBaC2YmRNTZRc7RWusw6apSpdEj3jo4CMb6W9nrF6tTnsJsJeyu6g==",
+          "integrity": "sha1-HVoNIPsScHx1imVfa7xDhrWTDWg=",
           "requires": {
-            "p-try": "2.0.0"
+            "p-try": "^2.0.0"
           }
         },
         "p-locate": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
           "requires": {
-            "p-limit": "2.1.0"
+            "p-limit": "^2.0.0"
           }
         },
         "p-try": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
-          "integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ=="
+          "integrity": "sha1-hQgLuHxkaI+keZb+j3376CEXYLE="
         },
         "string-width": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           }
         },
         "strip-ansi": {
@@ -1390,35 +1522,35 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         },
         "yargs": {
           "version": "12.0.5",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
-          "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
+          "integrity": "sha1-BfWZe2CWR7ZPZrgeO0sQo2jnrRM=",
           "requires": {
-            "cliui": "4.1.0",
-            "decamelize": "1.2.0",
-            "find-up": "3.0.0",
-            "get-caller-file": "1.0.3",
-            "os-locale": "3.1.0",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "2.1.1",
-            "which-module": "2.0.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "11.1.1"
+            "cliui": "^4.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^3.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1 || ^4.0.0",
+            "yargs-parser": "^11.1.1"
           }
         },
         "yargs-parser": {
           "version": "11.1.1",
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
-          "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
+          "integrity": "sha1-h5oIZZc7yp9rq1y987HGfsfTvPQ=",
           "requires": {
-            "camelcase": "5.0.0",
-            "decamelize": "1.2.0"
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
           }
         }
       }
@@ -1428,19 +1560,19 @@
       "resolved": "https://registry.npmjs.org/mochawesome-report-generator/-/mochawesome-report-generator-3.1.5.tgz",
       "integrity": "sha1-csdNaTyRiE967aKfcEfggnaaSGM=",
       "requires": {
-        "chalk": "2.4.1",
-        "dateformat": "3.0.3",
-        "fs-extra": "4.0.3",
-        "fsu": "1.1.1",
-        "lodash.isfunction": "3.0.9",
-        "opener": "1.5.1",
-        "prop-types": "15.7.2",
-        "react": "16.8.2",
-        "react-dom": "16.8.2",
-        "tcomb": "3.2.29",
-        "tcomb-validation": "3.4.1",
-        "validator": "9.4.1",
-        "yargs": "10.1.2"
+        "chalk": "^2.3.0",
+        "dateformat": "^3.0.2",
+        "fs-extra": "^4.0.2",
+        "fsu": "^1.0.2",
+        "lodash.isfunction": "^3.0.8",
+        "opener": "^1.4.2",
+        "prop-types": "^15.5.8",
+        "react": "^16.0.0",
+        "react-dom": "^16.0.0",
+        "tcomb": "^3.2.17",
+        "tcomb-validation": "^3.3.0",
+        "validator": "^9.1.2",
+        "yargs": "^10.0.3"
       },
       "dependencies": {
         "fs-extra": {
@@ -1448,9 +1580,9 @@
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
           "integrity": "sha1-DYUhIuW8W+tFP7Ao6cDJvzY0DJQ=",
           "requires": {
-            "graceful-fs": "4.1.11",
-            "jsonfile": "4.0.0",
-            "universalify": "0.1.2"
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
           }
         },
         "jsonfile": {
@@ -1458,7 +1590,7 @@
           "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
           "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
           "requires": {
-            "graceful-fs": "4.1.11"
+            "graceful-fs": "^4.1.6"
           }
         }
       }
@@ -1488,7 +1620,7 @@
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "requires": {
-        "path-key": "2.0.1"
+        "path-key": "^2.0.0"
       }
     },
     "npx": {
@@ -1506,7 +1638,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "string-width": "2.1.1"
+            "string-width": "^2.0.0"
           }
         },
         "ansi-regex": {
@@ -1519,7 +1651,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "balanced-match": {
@@ -1532,13 +1664,13 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ansi-align": "2.0.0",
-            "camelcase": "4.1.0",
-            "chalk": "2.3.2",
-            "cli-boxes": "1.0.0",
-            "string-width": "2.1.1",
-            "term-size": "1.2.0",
-            "widest-line": "2.0.0"
+            "ansi-align": "^2.0.0",
+            "camelcase": "^4.0.0",
+            "chalk": "^2.0.1",
+            "cli-boxes": "^1.0.0",
+            "string-width": "^2.0.0",
+            "term-size": "^1.2.0",
+            "widest-line": "^2.0.0"
           }
         },
         "brace-expansion": {
@@ -1546,7 +1678,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "balanced-match": "1.0.0",
+            "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -1570,9 +1702,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.3.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "ci-info": {
@@ -1590,9 +1722,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "string-width": "2.1.1",
-            "strip-ansi": "4.0.0",
-            "wrap-ansi": "2.1.0"
+            "string-width": "^2.1.1",
+            "strip-ansi": "^4.0.0",
+            "wrap-ansi": "^2.0.0"
           }
         },
         "code-point-at": {
@@ -1605,7 +1737,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "color-name": "1.1.3"
+            "color-name": "^1.1.1"
           }
         },
         "color-name": {
@@ -1623,12 +1755,12 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "dot-prop": "4.2.0",
-            "graceful-fs": "4.1.11",
-            "make-dir": "1.2.0",
-            "unique-string": "1.0.0",
-            "write-file-atomic": "2.3.0",
-            "xdg-basedir": "3.0.0"
+            "dot-prop": "^4.1.0",
+            "graceful-fs": "^4.1.2",
+            "make-dir": "^1.0.0",
+            "unique-string": "^1.0.0",
+            "write-file-atomic": "^2.0.0",
+            "xdg-basedir": "^3.0.0"
           }
         },
         "create-error-class": {
@@ -1636,7 +1768,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "capture-stack-trace": "1.0.0"
+            "capture-stack-trace": "^1.0.0"
           }
         },
         "cross-spawn": {
@@ -1644,9 +1776,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "lru-cache": "4.1.2",
-            "shebang-command": "1.2.0",
-            "which": "1.3.0"
+            "lru-cache": "^4.0.1",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
           }
         },
         "crypto-random-string": {
@@ -1669,7 +1801,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-obj": "1.0.1"
+            "is-obj": "^1.0.0"
           }
         },
         "dotenv": {
@@ -1692,13 +1824,13 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "cross-spawn": "5.1.0",
-            "get-stream": "3.0.0",
-            "is-stream": "1.1.0",
-            "npm-run-path": "2.0.2",
-            "p-finally": "1.0.0",
-            "signal-exit": "3.0.2",
-            "strip-eof": "1.0.0"
+            "cross-spawn": "^5.0.1",
+            "get-stream": "^3.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
           }
         },
         "find-up": {
@@ -1706,7 +1838,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "locate-path": "2.0.0"
+            "locate-path": "^2.0.0"
           }
         },
         "fs.realpath": {
@@ -1729,12 +1861,12 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "global-dirs": {
@@ -1742,7 +1874,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ini": "1.3.5"
+            "ini": "^1.3.4"
           }
         },
         "got": {
@@ -1750,17 +1882,17 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "create-error-class": "3.0.2",
-            "duplexer3": "0.1.4",
-            "get-stream": "3.0.0",
-            "is-redirect": "1.0.0",
-            "is-retry-allowed": "1.1.0",
-            "is-stream": "1.1.0",
-            "lowercase-keys": "1.0.1",
-            "safe-buffer": "5.1.1",
-            "timed-out": "4.0.1",
-            "unzip-response": "2.0.1",
-            "url-parse-lax": "1.0.0"
+            "create-error-class": "^3.0.0",
+            "duplexer3": "^0.1.4",
+            "get-stream": "^3.0.0",
+            "is-redirect": "^1.0.0",
+            "is-retry-allowed": "^1.0.0",
+            "is-stream": "^1.0.0",
+            "lowercase-keys": "^1.0.0",
+            "safe-buffer": "^5.0.1",
+            "timed-out": "^4.0.0",
+            "unzip-response": "^2.0.1",
+            "url-parse-lax": "^1.0.0"
           }
         },
         "graceful-fs": {
@@ -1793,8 +1925,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
+            "once": "^1.3.0",
+            "wrappy": "1"
           }
         },
         "inherits": {
@@ -1817,7 +1949,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ci-info": "1.1.3"
+            "ci-info": "^1.0.0"
           }
         },
         "is-fullwidth-code-point": {
@@ -1830,8 +1962,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "global-dirs": "0.1.1",
-            "is-path-inside": "1.0.1"
+            "global-dirs": "^0.1.0",
+            "is-path-inside": "^1.0.0"
           }
         },
         "is-npm": {
@@ -1849,7 +1981,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "path-is-inside": "1.0.2"
+            "path-is-inside": "^1.0.1"
           }
         },
         "is-redirect": {
@@ -1877,7 +2009,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "package-json": "4.0.1"
+            "package-json": "^4.0.0"
           }
         },
         "lcid": {
@@ -1885,7 +2017,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "invert-kv": "1.0.0"
+            "invert-kv": "^1.0.0"
           }
         },
         "libnpx": {
@@ -1893,14 +2025,14 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "dotenv": "5.0.1",
-            "npm-package-arg": "6.1.0",
-            "rimraf": "2.6.2",
-            "safe-buffer": "5.1.1",
-            "update-notifier": "2.4.0",
-            "which": "1.3.0",
-            "y18n": "4.0.0",
-            "yargs": "11.0.0"
+            "dotenv": "^5.0.1",
+            "npm-package-arg": "^6.0.0",
+            "rimraf": "^2.6.2",
+            "safe-buffer": "^5.1.0",
+            "update-notifier": "^2.3.0",
+            "which": "^1.3.0",
+            "y18n": "^4.0.0",
+            "yargs": "^11.0.0"
           }
         },
         "locate-path": {
@@ -1908,8 +2040,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "p-locate": "2.0.0",
-            "path-exists": "3.0.0"
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
           }
         },
         "lowercase-keys": {
@@ -1922,8 +2054,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "pseudomap": "1.0.2",
-            "yallist": "2.1.2"
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
           }
         },
         "make-dir": {
@@ -1931,7 +2063,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "pify": "3.0.0"
+            "pify": "^3.0.0"
           }
         },
         "mem": {
@@ -1939,7 +2071,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "mimic-fn": "1.2.0"
+            "mimic-fn": "^1.0.0"
           }
         },
         "mimic-fn": {
@@ -1952,7 +2084,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.11"
+            "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
@@ -1965,104 +2097,125 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "abbrev": "1.1.0",
-            "ansi-regex": "3.0.0",
-            "ansicolors": "0.3.2",
-            "ansistyles": "0.1.3",
-            "aproba": "1.1.2",
-            "archy": "1.0.0",
-            "bluebird": "3.5.0",
-            "cacache": "9.2.9",
-            "call-limit": "1.1.0",
-            "chownr": "1.0.1",
-            "cmd-shim": "2.0.2",
-            "columnify": "1.5.4",
-            "config-chain": "1.1.11",
-            "debuglog": "1.0.1",
-            "detect-indent": "5.0.0",
-            "dezalgo": "1.0.3",
-            "editor": "1.0.0",
-            "fs-vacuum": "1.2.10",
-            "fs-write-stream-atomic": "1.0.10",
-            "fstream": "1.0.11",
-            "fstream-npm": "1.2.1",
-            "glob": "7.1.2",
-            "graceful-fs": "4.1.11",
-            "has-unicode": "2.0.1",
-            "hosted-git-info": "2.5.0",
-            "iferr": "0.1.5",
-            "imurmurhash": "0.1.4",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "ini": "1.3.4",
-            "init-package-json": "1.10.1",
-            "JSONStream": "1.3.1",
-            "lazy-property": "1.0.0",
-            "lockfile": "1.0.3",
-            "lodash._baseindexof": "3.1.0",
-            "lodash._baseuniq": "4.6.0",
-            "lodash._bindcallback": "3.0.1",
-            "lodash._cacheindexof": "3.0.2",
-            "lodash._createcache": "3.1.2",
-            "lodash._getnative": "3.9.1",
-            "lodash.clonedeep": "4.5.0",
-            "lodash.restparam": "3.6.1",
-            "lodash.union": "4.6.0",
-            "lodash.uniq": "4.5.0",
-            "lodash.without": "4.4.0",
-            "lru-cache": "4.1.1",
-            "mississippi": "1.3.0",
-            "mkdirp": "0.5.1",
-            "move-concurrently": "1.0.1",
-            "node-gyp": "3.6.2",
-            "nopt": "4.0.1",
-            "normalize-package-data": "2.4.0",
-            "npm-cache-filename": "1.0.2",
-            "npm-install-checks": "3.0.0",
-            "npm-package-arg": "5.1.2",
-            "npm-registry-client": "8.4.0",
-            "npm-user-validate": "1.0.0",
-            "npmlog": "4.1.2",
-            "once": "1.4.0",
-            "opener": "1.4.3",
-            "osenv": "0.1.4",
-            "pacote": "2.7.38",
-            "path-is-inside": "1.0.2",
-            "promise-inflight": "1.0.1",
-            "read": "1.0.7",
-            "read-cmd-shim": "1.0.1",
-            "read-installed": "4.0.3",
-            "read-package-json": "2.0.9",
-            "read-package-tree": "5.1.6",
-            "readable-stream": "2.3.2",
-            "readdir-scoped-modules": "1.0.2",
-            "request": "2.81.0",
-            "retry": "0.10.1",
-            "rimraf": "2.6.1",
-            "safe-buffer": "5.1.1",
-            "semver": "5.3.0",
-            "sha": "2.0.1",
-            "slide": "1.1.6",
-            "sorted-object": "2.0.1",
-            "sorted-union-stream": "2.1.3",
-            "ssri": "4.1.6",
-            "strip-ansi": "4.0.0",
-            "tar": "2.2.1",
-            "text-table": "0.2.0",
+            "JSONStream": "~1.3.1",
+            "abbrev": "~1.1.0",
+            "ansi-regex": "~3.0.0",
+            "ansicolors": "~0.3.2",
+            "ansistyles": "~0.1.3",
+            "aproba": "~1.1.2",
+            "archy": "~1.0.0",
+            "bluebird": "~3.5.0",
+            "cacache": "~9.2.9",
+            "call-limit": "~1.1.0",
+            "chownr": "~1.0.1",
+            "cmd-shim": "~2.0.2",
+            "columnify": "~1.5.4",
+            "config-chain": "~1.1.11",
+            "debuglog": "*",
+            "detect-indent": "~5.0.0",
+            "dezalgo": "~1.0.3",
+            "editor": "~1.0.0",
+            "fs-vacuum": "~1.2.10",
+            "fs-write-stream-atomic": "~1.0.10",
+            "fstream": "~1.0.11",
+            "fstream-npm": "~1.2.1",
+            "glob": "~7.1.2",
+            "graceful-fs": "~4.1.11",
+            "has-unicode": "~2.0.1",
+            "hosted-git-info": "~2.5.0",
+            "iferr": "~0.1.5",
+            "imurmurhash": "*",
+            "inflight": "~1.0.6",
+            "inherits": "~2.0.3",
+            "ini": "~1.3.4",
+            "init-package-json": "~1.10.1",
+            "lazy-property": "~1.0.0",
+            "lockfile": "~1.0.3",
+            "lodash._baseindexof": "*",
+            "lodash._baseuniq": "~4.6.0",
+            "lodash._bindcallback": "*",
+            "lodash._cacheindexof": "*",
+            "lodash._createcache": "*",
+            "lodash._getnative": "*",
+            "lodash.clonedeep": "~4.5.0",
+            "lodash.restparam": "*",
+            "lodash.union": "~4.6.0",
+            "lodash.uniq": "~4.5.0",
+            "lodash.without": "~4.4.0",
+            "lru-cache": "~4.1.1",
+            "mississippi": "~1.3.0",
+            "mkdirp": "~0.5.1",
+            "move-concurrently": "~1.0.1",
+            "node-gyp": "~3.6.2",
+            "nopt": "~4.0.1",
+            "normalize-package-data": "~2.4.0",
+            "npm-cache-filename": "~1.0.2",
+            "npm-install-checks": "~3.0.0",
+            "npm-package-arg": "~5.1.2",
+            "npm-registry-client": "~8.4.0",
+            "npm-user-validate": "~1.0.0",
+            "npmlog": "~4.1.2",
+            "once": "~1.4.0",
+            "opener": "~1.4.3",
+            "osenv": "~0.1.4",
+            "pacote": "~2.7.38",
+            "path-is-inside": "~1.0.2",
+            "promise-inflight": "~1.0.1",
+            "read": "~1.0.7",
+            "read-cmd-shim": "~1.0.1",
+            "read-installed": "~4.0.3",
+            "read-package-json": "~2.0.9",
+            "read-package-tree": "~5.1.6",
+            "readable-stream": "~2.3.2",
+            "readdir-scoped-modules": "*",
+            "request": "~2.81.0",
+            "retry": "~0.10.1",
+            "rimraf": "~2.6.1",
+            "safe-buffer": "~5.1.1",
+            "semver": "~5.3.0",
+            "sha": "~2.0.1",
+            "slide": "~1.1.6",
+            "sorted-object": "~2.0.1",
+            "sorted-union-stream": "~2.1.3",
+            "ssri": "~4.1.6",
+            "strip-ansi": "~4.0.0",
+            "tar": "~2.2.1",
+            "text-table": "~0.2.0",
             "uid-number": "0.0.6",
-            "umask": "1.1.0",
-            "unique-filename": "1.1.0",
-            "unpipe": "1.0.0",
-            "update-notifier": "2.2.0",
-            "uuid": "3.1.0",
-            "validate-npm-package-license": "3.0.1",
-            "validate-npm-package-name": "3.0.0",
-            "which": "1.2.14",
-            "worker-farm": "1.3.1",
-            "wrappy": "1.0.2",
-            "write-file-atomic": "2.1.0"
+            "umask": "~1.1.0",
+            "unique-filename": "~1.1.0",
+            "unpipe": "~1.0.0",
+            "update-notifier": "~2.2.0",
+            "uuid": "~3.1.0",
+            "validate-npm-package-license": "*",
+            "validate-npm-package-name": "~3.0.0",
+            "which": "~1.2.14",
+            "worker-farm": "~1.3.1",
+            "wrappy": "~1.0.2",
+            "write-file-atomic": "~2.1.0"
           },
           "dependencies": {
+            "JSONStream": {
+              "version": "1.3.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "jsonparse": "^1.2.0",
+                "through": ">=2.2.7 <3"
+              },
+              "dependencies": {
+                "jsonparse": {
+                  "version": "1.3.1",
+                  "bundled": true,
+                  "dev": true
+                },
+                "through": {
+                  "version": "2.3.8",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            },
             "abbrev": {
               "version": "1.1.0",
               "bundled": true,
@@ -2103,19 +2256,19 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "bluebird": "3.5.0",
-                "chownr": "1.0.1",
-                "glob": "7.1.2",
-                "graceful-fs": "4.1.11",
-                "lru-cache": "4.1.1",
-                "mississippi": "1.3.0",
-                "mkdirp": "0.5.1",
-                "move-concurrently": "1.0.1",
-                "promise-inflight": "1.0.1",
-                "rimraf": "2.6.1",
-                "ssri": "4.1.6",
-                "unique-filename": "1.1.0",
-                "y18n": "3.2.1"
+                "bluebird": "^3.5.0",
+                "chownr": "^1.0.1",
+                "glob": "^7.1.2",
+                "graceful-fs": "^4.1.11",
+                "lru-cache": "^4.1.1",
+                "mississippi": "^1.3.0",
+                "mkdirp": "^0.5.1",
+                "move-concurrently": "^1.0.1",
+                "promise-inflight": "^1.0.1",
+                "rimraf": "^2.6.1",
+                "ssri": "^4.1.6",
+                "unique-filename": "^1.1.0",
+                "y18n": "^3.2.1"
               },
               "dependencies": {
                 "lru-cache": {
@@ -2123,8 +2276,8 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "pseudomap": "1.0.2",
-                    "yallist": "2.1.2"
+                    "pseudomap": "^1.0.2",
+                    "yallist": "^2.1.2"
                   },
                   "dependencies": {
                     "pseudomap": {
@@ -2161,8 +2314,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "graceful-fs": "4.1.11",
-                "mkdirp": "0.5.1"
+                "graceful-fs": "^4.1.2",
+                "mkdirp": "~0.5.0"
               }
             },
             "columnify": {
@@ -2170,8 +2323,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "strip-ansi": "3.0.1",
-                "wcwidth": "1.0.1"
+                "strip-ansi": "^3.0.0",
+                "wcwidth": "^1.0.0"
               },
               "dependencies": {
                 "strip-ansi": {
@@ -2179,7 +2332,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "ansi-regex": "2.1.1"
+                    "ansi-regex": "^2.0.0"
                   },
                   "dependencies": {
                     "ansi-regex": {
@@ -2194,7 +2347,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "defaults": "1.0.3"
+                    "defaults": "^1.0.3"
                   },
                   "dependencies": {
                     "defaults": {
@@ -2202,7 +2355,7 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "clone": "1.0.2"
+                        "clone": "^1.0.2"
                       },
                       "dependencies": {
                         "clone": {
@@ -2221,8 +2374,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "ini": "1.3.4",
-                "proto-list": "1.2.4"
+                "ini": "^1.3.4",
+                "proto-list": "~1.2.1"
               },
               "dependencies": {
                 "proto-list": {
@@ -2247,8 +2400,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "asap": "2.0.5",
-                "wrappy": "1.0.2"
+                "asap": "^2.0.0",
+                "wrappy": "1"
               },
               "dependencies": {
                 "asap": {
@@ -2268,9 +2421,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "graceful-fs": "4.1.11",
-                "path-is-inside": "1.0.2",
-                "rimraf": "2.6.1"
+                "graceful-fs": "^4.1.2",
+                "path-is-inside": "^1.0.1",
+                "rimraf": "^2.5.2"
               }
             },
             "fs-write-stream-atomic": {
@@ -2278,10 +2431,10 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "graceful-fs": "4.1.11",
-                "iferr": "0.1.5",
-                "imurmurhash": "0.1.4",
-                "readable-stream": "2.3.2"
+                "graceful-fs": "^4.1.2",
+                "iferr": "^0.1.5",
+                "imurmurhash": "^0.1.4",
+                "readable-stream": "1 || 2"
               }
             },
             "fstream": {
@@ -2289,10 +2442,10 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "graceful-fs": "4.1.11",
-                "inherits": "2.0.3",
-                "mkdirp": "0.5.1",
-                "rimraf": "2.6.1"
+                "graceful-fs": "^4.1.2",
+                "inherits": "~2.0.0",
+                "mkdirp": ">=0.5 0",
+                "rimraf": "2"
               }
             },
             "fstream-npm": {
@@ -2300,8 +2453,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "fstream-ignore": "1.0.5",
-                "inherits": "2.0.3"
+                "fstream-ignore": "^1.0.0",
+                "inherits": "2"
               },
               "dependencies": {
                 "fstream-ignore": {
@@ -2309,9 +2462,9 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "fstream": "1.0.11",
-                    "inherits": "2.0.3",
-                    "minimatch": "3.0.4"
+                    "fstream": "^1.0.0",
+                    "inherits": "2",
+                    "minimatch": "^3.0.0"
                   },
                   "dependencies": {
                     "minimatch": {
@@ -2319,7 +2472,7 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "brace-expansion": "1.1.8"
+                        "brace-expansion": "^1.1.7"
                       },
                       "dependencies": {
                         "brace-expansion": {
@@ -2327,7 +2480,7 @@
                           "bundled": true,
                           "dev": true,
                           "requires": {
-                            "balanced-match": "1.0.0",
+                            "balanced-match": "^1.0.0",
                             "concat-map": "0.0.1"
                           },
                           "dependencies": {
@@ -2354,12 +2507,12 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "fs.realpath": "1.0.0",
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.4",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.1"
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
               },
               "dependencies": {
                 "fs.realpath": {
@@ -2372,7 +2525,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "brace-expansion": "1.1.8"
+                    "brace-expansion": "^1.1.7"
                   },
                   "dependencies": {
                     "brace-expansion": {
@@ -2380,7 +2533,7 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "balanced-match": "1.0.0",
+                        "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
                       },
                       "dependencies": {
@@ -2435,8 +2588,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "once": "1.4.0",
-                "wrappy": "1.0.2"
+                "once": "^1.3.0",
+                "wrappy": "1"
               }
             },
             "inherits": {
@@ -2454,14 +2607,14 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "glob": "7.1.2",
-                "npm-package-arg": "5.1.2",
-                "promzard": "0.3.0",
-                "read": "1.0.7",
-                "read-package-json": "2.0.9",
-                "semver": "5.3.0",
-                "validate-npm-package-license": "3.0.1",
-                "validate-npm-package-name": "3.0.0"
+                "glob": "^7.1.1",
+                "npm-package-arg": "^4.0.0 || ^5.0.0",
+                "promzard": "^0.3.0",
+                "read": "~1.0.1",
+                "read-package-json": "1 || 2",
+                "semver": "2.x || 3.x || 4 || 5",
+                "validate-npm-package-license": "^3.0.1",
+                "validate-npm-package-name": "^3.0.0"
               },
               "dependencies": {
                 "promzard": {
@@ -2469,29 +2622,8 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "read": "1.0.7"
+                    "read": "1"
                   }
-                }
-              }
-            },
-            "JSONStream": {
-              "version": "1.3.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "jsonparse": "1.3.1",
-                "through": "2.3.8"
-              },
-              "dependencies": {
-                "jsonparse": {
-                  "version": "1.3.1",
-                  "bundled": true,
-                  "dev": true
-                },
-                "through": {
-                  "version": "2.3.8",
-                  "bundled": true,
-                  "dev": true
                 }
               }
             },
@@ -2515,8 +2647,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "lodash._createset": "4.0.3",
-                "lodash._root": "3.0.1"
+                "lodash._createset": "~4.0.0",
+                "lodash._root": "~3.0.0"
               },
               "dependencies": {
                 "lodash._createset": {
@@ -2546,7 +2678,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "lodash._getnative": "3.9.1"
+                "lodash._getnative": "^3.0.0"
               }
             },
             "lodash._getnative": {
@@ -2584,8 +2716,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "pseudomap": "1.0.2",
-                "yallist": "2.1.2"
+                "pseudomap": "^1.0.2",
+                "yallist": "^2.1.2"
               },
               "dependencies": {
                 "pseudomap": {
@@ -2605,16 +2737,16 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "concat-stream": "1.6.0",
-                "duplexify": "3.5.0",
-                "end-of-stream": "1.4.0",
-                "flush-write-stream": "1.0.2",
-                "from2": "2.3.0",
-                "parallel-transform": "1.1.0",
-                "pump": "1.0.2",
-                "pumpify": "1.3.5",
-                "stream-each": "1.2.0",
-                "through2": "2.0.3"
+                "concat-stream": "^1.5.0",
+                "duplexify": "^3.4.2",
+                "end-of-stream": "^1.1.0",
+                "flush-write-stream": "^1.0.0",
+                "from2": "^2.1.0",
+                "parallel-transform": "^1.1.0",
+                "pump": "^1.0.0",
+                "pumpify": "^1.3.3",
+                "stream-each": "^1.1.0",
+                "through2": "^2.0.0"
               },
               "dependencies": {
                 "concat-stream": {
@@ -2622,9 +2754,9 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "inherits": "2.0.3",
-                    "readable-stream": "2.3.2",
-                    "typedarray": "0.0.6"
+                    "inherits": "^2.0.3",
+                    "readable-stream": "^2.2.2",
+                    "typedarray": "^0.0.6"
                   },
                   "dependencies": {
                     "typedarray": {
@@ -2640,9 +2772,9 @@
                   "dev": true,
                   "requires": {
                     "end-of-stream": "1.0.0",
-                    "inherits": "2.0.3",
-                    "readable-stream": "2.3.2",
-                    "stream-shift": "1.0.0"
+                    "inherits": "^2.0.1",
+                    "readable-stream": "^2.0.0",
+                    "stream-shift": "^1.0.0"
                   },
                   "dependencies": {
                     "end-of-stream": {
@@ -2650,7 +2782,7 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "once": "1.3.3"
+                        "once": "~1.3.0"
                       },
                       "dependencies": {
                         "once": {
@@ -2658,7 +2790,7 @@
                           "bundled": true,
                           "dev": true,
                           "requires": {
-                            "wrappy": "1.0.2"
+                            "wrappy": "1"
                           }
                         }
                       }
@@ -2675,7 +2807,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "once": "1.4.0"
+                    "once": "^1.4.0"
                   }
                 },
                 "flush-write-stream": {
@@ -2683,8 +2815,8 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "inherits": "2.0.3",
-                    "readable-stream": "2.3.2"
+                    "inherits": "^2.0.1",
+                    "readable-stream": "^2.0.4"
                   }
                 },
                 "from2": {
@@ -2692,8 +2824,8 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "inherits": "2.0.3",
-                    "readable-stream": "2.3.2"
+                    "inherits": "^2.0.1",
+                    "readable-stream": "^2.0.0"
                   }
                 },
                 "parallel-transform": {
@@ -2701,9 +2833,9 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "cyclist": "0.2.2",
-                    "inherits": "2.0.3",
-                    "readable-stream": "2.3.2"
+                    "cyclist": "~0.2.2",
+                    "inherits": "^2.0.3",
+                    "readable-stream": "^2.1.5"
                   },
                   "dependencies": {
                     "cyclist": {
@@ -2718,8 +2850,8 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "end-of-stream": "1.4.0",
-                    "once": "1.4.0"
+                    "end-of-stream": "^1.1.0",
+                    "once": "^1.3.1"
                   }
                 },
                 "pumpify": {
@@ -2727,9 +2859,9 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "duplexify": "3.5.0",
-                    "inherits": "2.0.3",
-                    "pump": "1.0.2"
+                    "duplexify": "^3.1.2",
+                    "inherits": "^2.0.1",
+                    "pump": "^1.0.0"
                   }
                 },
                 "stream-each": {
@@ -2737,8 +2869,8 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "end-of-stream": "1.4.0",
-                    "stream-shift": "1.0.0"
+                    "end-of-stream": "^1.1.0",
+                    "stream-shift": "^1.0.0"
                   },
                   "dependencies": {
                     "stream-shift": {
@@ -2753,8 +2885,8 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "readable-stream": "2.3.2",
-                    "xtend": "4.0.1"
+                    "readable-stream": "^2.1.5",
+                    "xtend": "~4.0.1"
                   },
                   "dependencies": {
                     "xtend": {
@@ -2786,12 +2918,12 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "aproba": "1.1.2",
-                "copy-concurrently": "1.0.3",
-                "fs-write-stream-atomic": "1.0.10",
-                "mkdirp": "0.5.1",
-                "rimraf": "2.6.1",
-                "run-queue": "1.0.3"
+                "aproba": "^1.1.1",
+                "copy-concurrently": "^1.0.0",
+                "fs-write-stream-atomic": "^1.0.8",
+                "mkdirp": "^0.5.1",
+                "rimraf": "^2.5.4",
+                "run-queue": "^1.0.3"
               },
               "dependencies": {
                 "copy-concurrently": {
@@ -2799,12 +2931,12 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "aproba": "1.1.2",
-                    "fs-write-stream-atomic": "1.0.10",
-                    "iferr": "0.1.5",
-                    "mkdirp": "0.5.1",
-                    "rimraf": "2.6.1",
-                    "run-queue": "1.0.3"
+                    "aproba": "^1.1.1",
+                    "fs-write-stream-atomic": "^1.0.8",
+                    "iferr": "^0.1.5",
+                    "mkdirp": "^0.5.1",
+                    "rimraf": "^2.5.4",
+                    "run-queue": "^1.0.0"
                   }
                 },
                 "run-queue": {
@@ -2812,7 +2944,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "aproba": "1.1.2"
+                    "aproba": "^1.1.1"
                   }
                 }
               }
@@ -2822,19 +2954,19 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "fstream": "1.0.11",
-                "glob": "7.1.2",
-                "graceful-fs": "4.1.11",
-                "minimatch": "3.0.4",
-                "mkdirp": "0.5.1",
-                "nopt": "3.0.6",
-                "npmlog": "4.1.2",
-                "osenv": "0.1.4",
-                "request": "2.81.0",
-                "rimraf": "2.6.1",
-                "semver": "5.3.0",
-                "tar": "2.2.1",
-                "which": "1.2.14"
+                "fstream": "^1.0.0",
+                "glob": "^7.0.3",
+                "graceful-fs": "^4.1.2",
+                "minimatch": "^3.0.2",
+                "mkdirp": "^0.5.0",
+                "nopt": "2 || 3",
+                "npmlog": "0 || 1 || 2 || 3 || 4",
+                "osenv": "0",
+                "request": "2",
+                "rimraf": "2",
+                "semver": "~5.3.0",
+                "tar": "^2.0.0",
+                "which": "1"
               },
               "dependencies": {
                 "minimatch": {
@@ -2842,7 +2974,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "brace-expansion": "1.1.8"
+                    "brace-expansion": "^1.1.7"
                   },
                   "dependencies": {
                     "brace-expansion": {
@@ -2850,7 +2982,7 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "balanced-match": "1.0.0",
+                        "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
                       },
                       "dependencies": {
@@ -2873,7 +3005,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "abbrev": "1.1.0"
+                    "abbrev": "1"
                   }
                 }
               }
@@ -2883,8 +3015,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "abbrev": "1.1.0",
-                "osenv": "0.1.4"
+                "abbrev": "1",
+                "osenv": "^0.1.4"
               }
             },
             "normalize-package-data": {
@@ -2892,10 +3024,10 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "hosted-git-info": "2.5.0",
-                "is-builtin-module": "1.0.0",
-                "semver": "5.3.0",
-                "validate-npm-package-license": "3.0.1"
+                "hosted-git-info": "^2.1.4",
+                "is-builtin-module": "^1.0.0",
+                "semver": "2 || 3 || 4 || 5",
+                "validate-npm-package-license": "^3.0.1"
               },
               "dependencies": {
                 "is-builtin-module": {
@@ -2903,7 +3035,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "builtin-modules": "1.1.1"
+                    "builtin-modules": "^1.0.0"
                   },
                   "dependencies": {
                     "builtin-modules": {
@@ -2925,7 +3057,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "semver": "5.3.0"
+                "semver": "^2.3.0 || 3.x || 4 || 5"
               }
             },
             "npm-package-arg": {
@@ -2933,10 +3065,10 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "hosted-git-info": "2.5.0",
-                "osenv": "0.1.4",
-                "semver": "5.3.0",
-                "validate-npm-package-name": "3.0.0"
+                "hosted-git-info": "^2.4.2",
+                "osenv": "^0.1.4",
+                "semver": "^5.1.0",
+                "validate-npm-package-name": "^3.0.0"
               }
             },
             "npm-registry-client": {
@@ -2944,17 +3076,17 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "concat-stream": "1.6.0",
-                "graceful-fs": "4.1.11",
-                "normalize-package-data": "2.4.0",
-                "npm-package-arg": "5.1.2",
-                "npmlog": "4.1.2",
-                "once": "1.4.0",
-                "request": "2.81.0",
-                "retry": "0.10.1",
-                "semver": "5.3.0",
-                "slide": "1.1.6",
-                "ssri": "4.1.6"
+                "concat-stream": "^1.5.2",
+                "graceful-fs": "^4.1.6",
+                "normalize-package-data": "~1.0.1 || ^2.0.0",
+                "npm-package-arg": "^3.0.0 || ^4.0.0 || ^5.0.0",
+                "npmlog": "2 || ^3.1.0 || ^4.0.0",
+                "once": "^1.3.3",
+                "request": "^2.74.0",
+                "retry": "^0.10.0",
+                "semver": "2 >=2.2.1 || 3.x || 4 || 5",
+                "slide": "^1.1.3",
+                "ssri": "^4.1.2"
               },
               "dependencies": {
                 "concat-stream": {
@@ -2962,9 +3094,9 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "inherits": "2.0.3",
-                    "readable-stream": "2.3.2",
-                    "typedarray": "0.0.6"
+                    "inherits": "^2.0.3",
+                    "readable-stream": "^2.2.2",
+                    "typedarray": "^0.0.6"
                   },
                   "dependencies": {
                     "typedarray": {
@@ -2986,10 +3118,10 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "are-we-there-yet": "1.1.4",
-                "console-control-strings": "1.1.0",
-                "gauge": "2.7.4",
-                "set-blocking": "2.0.0"
+                "are-we-there-yet": "~1.1.2",
+                "console-control-strings": "~1.1.0",
+                "gauge": "~2.7.3",
+                "set-blocking": "~2.0.0"
               },
               "dependencies": {
                 "are-we-there-yet": {
@@ -2997,8 +3129,8 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "delegates": "1.0.0",
-                    "readable-stream": "2.3.2"
+                    "delegates": "^1.0.0",
+                    "readable-stream": "^2.0.6"
                   },
                   "dependencies": {
                     "delegates": {
@@ -3018,14 +3150,14 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "aproba": "1.1.2",
-                    "console-control-strings": "1.1.0",
-                    "has-unicode": "2.0.1",
-                    "object-assign": "4.1.1",
-                    "signal-exit": "3.0.2",
-                    "string-width": "1.0.2",
-                    "strip-ansi": "3.0.1",
-                    "wide-align": "1.1.2"
+                    "aproba": "^1.0.3",
+                    "console-control-strings": "^1.0.0",
+                    "has-unicode": "^2.0.0",
+                    "object-assign": "^4.1.0",
+                    "signal-exit": "^3.0.0",
+                    "string-width": "^1.0.1",
+                    "strip-ansi": "^3.0.1",
+                    "wide-align": "^1.1.0"
                   },
                   "dependencies": {
                     "object-assign": {
@@ -3043,9 +3175,9 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "code-point-at": "1.1.0",
-                        "is-fullwidth-code-point": "1.0.0",
-                        "strip-ansi": "3.0.1"
+                        "code-point-at": "^1.0.0",
+                        "is-fullwidth-code-point": "^1.0.0",
+                        "strip-ansi": "^3.0.0"
                       },
                       "dependencies": {
                         "code-point-at": {
@@ -3058,7 +3190,7 @@
                           "bundled": true,
                           "dev": true,
                           "requires": {
-                            "number-is-nan": "1.0.1"
+                            "number-is-nan": "^1.0.0"
                           },
                           "dependencies": {
                             "number-is-nan": {
@@ -3075,7 +3207,7 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "ansi-regex": "2.1.1"
+                        "ansi-regex": "^2.0.0"
                       },
                       "dependencies": {
                         "ansi-regex": {
@@ -3090,7 +3222,7 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "string-width": "1.0.2"
+                        "string-width": "^1.0.2"
                       }
                     }
                   }
@@ -3107,7 +3239,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "wrappy": "1.0.2"
+                "wrappy": "1"
               }
             },
             "opener": {
@@ -3120,8 +3252,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "os-homedir": "1.0.2",
-                "os-tmpdir": "1.0.2"
+                "os-homedir": "^1.0.0",
+                "os-tmpdir": "^1.0.0"
               },
               "dependencies": {
                 "os-homedir": {
@@ -3141,27 +3273,27 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "bluebird": "3.5.0",
-                "cacache": "9.2.9",
-                "glob": "7.1.2",
-                "lru-cache": "4.1.1",
-                "make-fetch-happen": "2.4.13",
-                "minimatch": "3.0.4",
-                "mississippi": "1.3.0",
-                "normalize-package-data": "2.4.0",
-                "npm-package-arg": "5.1.2",
-                "npm-pick-manifest": "1.0.4",
-                "osenv": "0.1.4",
-                "promise-inflight": "1.0.1",
-                "promise-retry": "1.1.1",
-                "protoduck": "4.0.0",
-                "safe-buffer": "5.1.1",
-                "semver": "5.3.0",
-                "ssri": "4.1.6",
-                "tar-fs": "1.15.3",
-                "tar-stream": "1.5.4",
-                "unique-filename": "1.1.0",
-                "which": "1.2.14"
+                "bluebird": "^3.5.0",
+                "cacache": "^9.2.9",
+                "glob": "^7.1.2",
+                "lru-cache": "^4.1.1",
+                "make-fetch-happen": "^2.4.13",
+                "minimatch": "^3.0.4",
+                "mississippi": "^1.2.0",
+                "normalize-package-data": "^2.4.0",
+                "npm-package-arg": "^5.1.2",
+                "npm-pick-manifest": "^1.0.4",
+                "osenv": "^0.1.4",
+                "promise-inflight": "^1.0.1",
+                "promise-retry": "^1.1.1",
+                "protoduck": "^4.0.0",
+                "safe-buffer": "^5.1.1",
+                "semver": "^5.3.0",
+                "ssri": "^4.1.6",
+                "tar-fs": "^1.15.3",
+                "tar-stream": "^1.5.4",
+                "unique-filename": "^1.1.0",
+                "which": "^1.2.12"
               },
               "dependencies": {
                 "make-fetch-happen": {
@@ -3169,17 +3301,17 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "agentkeepalive": "3.3.0",
-                    "cacache": "9.2.9",
-                    "http-cache-semantics": "3.7.3",
-                    "http-proxy-agent": "2.0.0",
-                    "https-proxy-agent": "2.0.0",
-                    "lru-cache": "4.1.1",
-                    "mississippi": "1.3.0",
-                    "node-fetch-npm": "2.0.1",
-                    "promise-retry": "1.1.1",
-                    "socks-proxy-agent": "3.0.0",
-                    "ssri": "4.1.6"
+                    "agentkeepalive": "^3.3.0",
+                    "cacache": "^9.2.9",
+                    "http-cache-semantics": "^3.7.3",
+                    "http-proxy-agent": "^2.0.0",
+                    "https-proxy-agent": "^2.0.0",
+                    "lru-cache": "^4.1.1",
+                    "mississippi": "^1.2.0",
+                    "node-fetch-npm": "^2.0.1",
+                    "promise-retry": "^1.1.1",
+                    "socks-proxy-agent": "^3.0.0",
+                    "ssri": "^4.1.6"
                   },
                   "dependencies": {
                     "agentkeepalive": {
@@ -3187,7 +3319,7 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "humanize-ms": "1.2.1"
+                        "humanize-ms": "^1.2.1"
                       },
                       "dependencies": {
                         "humanize-ms": {
@@ -3195,7 +3327,7 @@
                           "bundled": true,
                           "dev": true,
                           "requires": {
-                            "ms": "2.0.0"
+                            "ms": "^2.0.0"
                           },
                           "dependencies": {
                             "ms": {
@@ -3217,8 +3349,8 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "agent-base": "4.1.0",
-                        "debug": "2.6.8"
+                        "agent-base": "4",
+                        "debug": "2"
                       },
                       "dependencies": {
                         "agent-base": {
@@ -3226,7 +3358,7 @@
                           "bundled": true,
                           "dev": true,
                           "requires": {
-                            "es6-promisify": "5.0.0"
+                            "es6-promisify": "^5.0.0"
                           },
                           "dependencies": {
                             "es6-promisify": {
@@ -3234,7 +3366,7 @@
                               "bundled": true,
                               "dev": true,
                               "requires": {
-                                "es6-promise": "4.1.1"
+                                "es6-promise": "^4.0.3"
                               },
                               "dependencies": {
                                 "es6-promise": {
@@ -3268,8 +3400,8 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "agent-base": "4.1.0",
-                        "debug": "2.6.8"
+                        "agent-base": "^4.1.0",
+                        "debug": "^2.4.1"
                       },
                       "dependencies": {
                         "agent-base": {
@@ -3277,7 +3409,7 @@
                           "bundled": true,
                           "dev": true,
                           "requires": {
-                            "es6-promisify": "5.0.0"
+                            "es6-promisify": "^5.0.0"
                           },
                           "dependencies": {
                             "es6-promisify": {
@@ -3285,7 +3417,7 @@
                               "bundled": true,
                               "dev": true,
                               "requires": {
-                                "es6-promise": "4.1.1"
+                                "es6-promise": "^4.0.3"
                               },
                               "dependencies": {
                                 "es6-promise": {
@@ -3319,9 +3451,9 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "encoding": "0.1.12",
-                        "json-parse-helpfulerror": "1.0.3",
-                        "safe-buffer": "5.1.1"
+                        "encoding": "^0.1.11",
+                        "json-parse-helpfulerror": "^1.0.3",
+                        "safe-buffer": "^5.0.1"
                       },
                       "dependencies": {
                         "encoding": {
@@ -3329,7 +3461,7 @@
                           "bundled": true,
                           "dev": true,
                           "requires": {
-                            "iconv-lite": "0.4.18"
+                            "iconv-lite": "~0.4.13"
                           },
                           "dependencies": {
                             "iconv-lite": {
@@ -3344,7 +3476,7 @@
                           "bundled": true,
                           "dev": true,
                           "requires": {
-                            "jju": "1.3.0"
+                            "jju": "^1.1.0"
                           },
                           "dependencies": {
                             "jju": {
@@ -3361,8 +3493,8 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "agent-base": "4.1.0",
-                        "socks": "1.1.10"
+                        "agent-base": "^4.0.1",
+                        "socks": "^1.1.10"
                       },
                       "dependencies": {
                         "agent-base": {
@@ -3370,7 +3502,7 @@
                           "bundled": true,
                           "dev": true,
                           "requires": {
-                            "es6-promisify": "5.0.0"
+                            "es6-promisify": "^5.0.0"
                           },
                           "dependencies": {
                             "es6-promisify": {
@@ -3378,7 +3510,7 @@
                               "bundled": true,
                               "dev": true,
                               "requires": {
-                                "es6-promise": "4.1.1"
+                                "es6-promise": "^4.0.3"
                               },
                               "dependencies": {
                                 "es6-promise": {
@@ -3395,8 +3527,8 @@
                           "bundled": true,
                           "dev": true,
                           "requires": {
-                            "ip": "1.1.5",
-                            "smart-buffer": "1.1.15"
+                            "ip": "^1.1.4",
+                            "smart-buffer": "^1.0.13"
                           },
                           "dependencies": {
                             "ip": {
@@ -3420,7 +3552,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "brace-expansion": "1.1.8"
+                    "brace-expansion": "^1.1.7"
                   },
                   "dependencies": {
                     "brace-expansion": {
@@ -3428,7 +3560,7 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "balanced-match": "1.0.0",
+                        "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
                       },
                       "dependencies": {
@@ -3451,8 +3583,8 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "npm-package-arg": "5.1.2",
-                    "semver": "5.3.0"
+                    "npm-package-arg": "^5.1.2",
+                    "semver": "^5.3.0"
                   }
                 },
                 "promise-retry": {
@@ -3460,8 +3592,8 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "err-code": "1.1.2",
-                    "retry": "0.10.1"
+                    "err-code": "^1.0.0",
+                    "retry": "^0.10.0"
                   },
                   "dependencies": {
                     "err-code": {
@@ -3476,7 +3608,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "genfun": "4.0.1"
+                    "genfun": "^4.0.1"
                   },
                   "dependencies": {
                     "genfun": {
@@ -3491,10 +3623,10 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "chownr": "1.0.1",
-                    "mkdirp": "0.5.1",
-                    "pump": "1.0.2",
-                    "tar-stream": "1.5.4"
+                    "chownr": "^1.0.1",
+                    "mkdirp": "^0.5.1",
+                    "pump": "^1.0.0",
+                    "tar-stream": "^1.1.2"
                   },
                   "dependencies": {
                     "pump": {
@@ -3502,8 +3634,8 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "end-of-stream": "1.4.0",
-                        "once": "1.4.0"
+                        "end-of-stream": "^1.1.0",
+                        "once": "^1.3.1"
                       },
                       "dependencies": {
                         "end-of-stream": {
@@ -3511,7 +3643,7 @@
                           "bundled": true,
                           "dev": true,
                           "requires": {
-                            "once": "1.4.0"
+                            "once": "^1.4.0"
                           }
                         }
                       }
@@ -3523,10 +3655,10 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "bl": "1.2.1",
-                    "end-of-stream": "1.4.0",
-                    "readable-stream": "2.3.2",
-                    "xtend": "4.0.1"
+                    "bl": "^1.0.0",
+                    "end-of-stream": "^1.0.0",
+                    "readable-stream": "^2.0.0",
+                    "xtend": "^4.0.0"
                   },
                   "dependencies": {
                     "bl": {
@@ -3534,7 +3666,7 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "readable-stream": "2.3.2"
+                        "readable-stream": "^2.0.5"
                       }
                     },
                     "end-of-stream": {
@@ -3542,7 +3674,7 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "once": "1.4.0"
+                        "once": "^1.4.0"
                       }
                     },
                     "xtend": {
@@ -3569,7 +3701,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "mute-stream": "0.0.7"
+                "mute-stream": "~0.0.4"
               },
               "dependencies": {
                 "mute-stream": {
@@ -3584,7 +3716,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "graceful-fs": "4.1.11"
+                "graceful-fs": "^4.1.2"
               }
             },
             "read-installed": {
@@ -3592,13 +3724,13 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "debuglog": "1.0.1",
-                "graceful-fs": "4.1.11",
-                "read-package-json": "2.0.9",
-                "readdir-scoped-modules": "1.0.2",
-                "semver": "5.3.0",
-                "slide": "1.1.6",
-                "util-extend": "1.0.3"
+                "debuglog": "^1.0.1",
+                "graceful-fs": "^4.1.2",
+                "read-package-json": "^2.0.0",
+                "readdir-scoped-modules": "^1.0.0",
+                "semver": "2 || 3 || 4 || 5",
+                "slide": "~1.1.3",
+                "util-extend": "^1.0.1"
               },
               "dependencies": {
                 "util-extend": {
@@ -3613,10 +3745,10 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "glob": "7.1.2",
-                "graceful-fs": "4.1.11",
-                "json-parse-helpfulerror": "1.0.3",
-                "normalize-package-data": "2.4.0"
+                "glob": "^7.1.1",
+                "graceful-fs": "^4.1.2",
+                "json-parse-helpfulerror": "^1.0.2",
+                "normalize-package-data": "^2.0.0"
               },
               "dependencies": {
                 "json-parse-helpfulerror": {
@@ -3624,7 +3756,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "jju": "1.3.0"
+                    "jju": "^1.1.0"
                   },
                   "dependencies": {
                     "jju": {
@@ -3641,11 +3773,11 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "debuglog": "1.0.1",
-                "dezalgo": "1.0.3",
-                "once": "1.4.0",
-                "read-package-json": "2.0.9",
-                "readdir-scoped-modules": "1.0.2"
+                "debuglog": "^1.0.1",
+                "dezalgo": "^1.0.0",
+                "once": "^1.3.0",
+                "read-package-json": "^2.0.0",
+                "readdir-scoped-modules": "^1.0.0"
               }
             },
             "readable-stream": {
@@ -3653,13 +3785,13 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "1.0.0",
-                "process-nextick-args": "1.0.7",
-                "safe-buffer": "5.1.1",
-                "string_decoder": "1.0.3",
-                "util-deprecate": "1.0.2"
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~1.0.6",
+                "safe-buffer": "~5.1.0",
+                "string_decoder": "~1.0.0",
+                "util-deprecate": "~1.0.1"
               },
               "dependencies": {
                 "core-util-is": {
@@ -3682,7 +3814,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "safe-buffer": "5.1.1"
+                    "safe-buffer": "~5.1.0"
                   }
                 },
                 "util-deprecate": {
@@ -3697,10 +3829,10 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "debuglog": "1.0.1",
-                "dezalgo": "1.0.3",
-                "graceful-fs": "4.1.11",
-                "once": "1.4.0"
+                "debuglog": "^1.0.1",
+                "dezalgo": "^1.0.0",
+                "graceful-fs": "^4.1.2",
+                "once": "^1.3.0"
               }
             },
             "request": {
@@ -3708,28 +3840,28 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "aws-sign2": "0.6.0",
-                "aws4": "1.6.0",
-                "caseless": "0.12.0",
-                "combined-stream": "1.0.5",
-                "extend": "3.0.1",
-                "forever-agent": "0.6.1",
-                "form-data": "2.1.4",
-                "har-validator": "4.2.1",
-                "hawk": "3.1.3",
-                "http-signature": "1.1.1",
-                "is-typedarray": "1.0.0",
-                "isstream": "0.1.2",
-                "json-stringify-safe": "5.0.1",
-                "mime-types": "2.1.15",
-                "oauth-sign": "0.8.2",
-                "performance-now": "0.2.0",
-                "qs": "6.4.0",
-                "safe-buffer": "5.1.1",
-                "stringstream": "0.0.5",
-                "tough-cookie": "2.3.2",
-                "tunnel-agent": "0.6.0",
-                "uuid": "3.1.0"
+                "aws-sign2": "~0.6.0",
+                "aws4": "^1.2.1",
+                "caseless": "~0.12.0",
+                "combined-stream": "~1.0.5",
+                "extend": "~3.0.0",
+                "forever-agent": "~0.6.1",
+                "form-data": "~2.1.1",
+                "har-validator": "~4.2.1",
+                "hawk": "~3.1.3",
+                "http-signature": "~1.1.0",
+                "is-typedarray": "~1.0.0",
+                "isstream": "~0.1.2",
+                "json-stringify-safe": "~5.0.1",
+                "mime-types": "~2.1.7",
+                "oauth-sign": "~0.8.1",
+                "performance-now": "^0.2.0",
+                "qs": "~6.4.0",
+                "safe-buffer": "^5.0.1",
+                "stringstream": "~0.0.4",
+                "tough-cookie": "~2.3.0",
+                "tunnel-agent": "^0.6.0",
+                "uuid": "^3.0.0"
               },
               "dependencies": {
                 "aws-sign2": {
@@ -3752,7 +3884,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "delayed-stream": "1.0.0"
+                    "delayed-stream": "~1.0.0"
                   },
                   "dependencies": {
                     "delayed-stream": {
@@ -3777,9 +3909,9 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "asynckit": "0.4.0",
-                    "combined-stream": "1.0.5",
-                    "mime-types": "2.1.15"
+                    "asynckit": "^0.4.0",
+                    "combined-stream": "^1.0.5",
+                    "mime-types": "^2.1.12"
                   },
                   "dependencies": {
                     "asynckit": {
@@ -3794,8 +3926,8 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "ajv": "4.11.8",
-                    "har-schema": "1.0.5"
+                    "ajv": "^4.9.1",
+                    "har-schema": "^1.0.5"
                   },
                   "dependencies": {
                     "ajv": {
@@ -3803,8 +3935,8 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "co": "4.6.0",
-                        "json-stable-stringify": "1.0.1"
+                        "co": "^4.6.0",
+                        "json-stable-stringify": "^1.0.1"
                       },
                       "dependencies": {
                         "co": {
@@ -3817,7 +3949,7 @@
                           "bundled": true,
                           "dev": true,
                           "requires": {
-                            "jsonify": "0.0.0"
+                            "jsonify": "~0.0.0"
                           },
                           "dependencies": {
                             "jsonify": {
@@ -3841,10 +3973,10 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "boom": "2.10.1",
-                    "cryptiles": "2.0.5",
-                    "hoek": "2.16.3",
-                    "sntp": "1.0.9"
+                    "boom": "2.x.x",
+                    "cryptiles": "2.x.x",
+                    "hoek": "2.x.x",
+                    "sntp": "1.x.x"
                   },
                   "dependencies": {
                     "boom": {
@@ -3852,7 +3984,7 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "hoek": "2.16.3"
+                        "hoek": "2.x.x"
                       }
                     },
                     "cryptiles": {
@@ -3860,7 +3992,7 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "boom": "2.10.1"
+                        "boom": "2.x.x"
                       }
                     },
                     "hoek": {
@@ -3873,7 +4005,7 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "hoek": "2.16.3"
+                        "hoek": "2.x.x"
                       }
                     }
                   }
@@ -3883,9 +4015,9 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "assert-plus": "0.2.0",
-                    "jsprim": "1.4.0",
-                    "sshpk": "1.13.1"
+                    "assert-plus": "^0.2.0",
+                    "jsprim": "^1.2.2",
+                    "sshpk": "^1.7.0"
                   },
                   "dependencies": {
                     "assert-plus": {
@@ -3934,14 +4066,14 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "asn1": "0.2.3",
-                        "assert-plus": "1.0.0",
-                        "bcrypt-pbkdf": "1.0.1",
-                        "dashdash": "1.14.1",
-                        "ecc-jsbn": "0.1.1",
-                        "getpass": "0.1.7",
-                        "jsbn": "0.1.1",
-                        "tweetnacl": "0.14.5"
+                        "asn1": "~0.2.3",
+                        "assert-plus": "^1.0.0",
+                        "bcrypt-pbkdf": "^1.0.0",
+                        "dashdash": "^1.12.0",
+                        "ecc-jsbn": "~0.1.1",
+                        "getpass": "^0.1.1",
+                        "jsbn": "~0.1.0",
+                        "tweetnacl": "~0.14.0"
                       },
                       "dependencies": {
                         "asn1": {
@@ -3960,7 +4092,7 @@
                           "dev": true,
                           "optional": true,
                           "requires": {
-                            "tweetnacl": "0.14.5"
+                            "tweetnacl": "^0.14.3"
                           }
                         },
                         "dashdash": {
@@ -3968,7 +4100,7 @@
                           "bundled": true,
                           "dev": true,
                           "requires": {
-                            "assert-plus": "1.0.0"
+                            "assert-plus": "^1.0.0"
                           }
                         },
                         "ecc-jsbn": {
@@ -3977,7 +4109,7 @@
                           "dev": true,
                           "optional": true,
                           "requires": {
-                            "jsbn": "0.1.1"
+                            "jsbn": "~0.1.0"
                           }
                         },
                         "getpass": {
@@ -3985,7 +4117,7 @@
                           "bundled": true,
                           "dev": true,
                           "requires": {
-                            "assert-plus": "1.0.0"
+                            "assert-plus": "^1.0.0"
                           }
                         },
                         "jsbn": {
@@ -4024,7 +4156,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "mime-db": "1.27.0"
+                    "mime-db": "~1.27.0"
                   },
                   "dependencies": {
                     "mime-db": {
@@ -4059,7 +4191,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "punycode": "1.4.1"
+                    "punycode": "^1.4.1"
                   },
                   "dependencies": {
                     "punycode": {
@@ -4074,7 +4206,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "safe-buffer": "5.1.1"
+                    "safe-buffer": "^5.0.1"
                   }
                 }
               }
@@ -4089,7 +4221,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "glob": "7.1.2"
+                "glob": "^7.0.5"
               }
             },
             "safe-buffer": {
@@ -4107,8 +4239,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "graceful-fs": "4.1.11",
-                "readable-stream": "2.3.2"
+                "graceful-fs": "^4.1.2",
+                "readable-stream": "^2.0.2"
               }
             },
             "slide": {
@@ -4126,8 +4258,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "from2": "1.3.0",
-                "stream-iterate": "1.2.0"
+                "from2": "^1.3.0",
+                "stream-iterate": "^1.1.0"
               },
               "dependencies": {
                 "from2": {
@@ -4135,8 +4267,8 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "inherits": "2.0.3",
-                    "readable-stream": "1.1.14"
+                    "inherits": "~2.0.1",
+                    "readable-stream": "~1.1.10"
                   },
                   "dependencies": {
                     "readable-stream": {
@@ -4144,10 +4276,10 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
                         "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
+                        "string_decoder": "~0.10.x"
                       },
                       "dependencies": {
                         "core-util-is": {
@@ -4174,8 +4306,8 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "readable-stream": "2.3.2",
-                    "stream-shift": "1.0.0"
+                    "readable-stream": "^2.1.5",
+                    "stream-shift": "^1.0.0"
                   },
                   "dependencies": {
                     "stream-shift": {
@@ -4192,7 +4324,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "safe-buffer": "5.1.1"
+                "safe-buffer": "^5.1.0"
               }
             },
             "strip-ansi": {
@@ -4200,7 +4332,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "ansi-regex": "3.0.0"
+                "ansi-regex": "^3.0.0"
               },
               "dependencies": {
                 "ansi-regex": {
@@ -4215,9 +4347,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "block-stream": "0.0.9",
-                "fstream": "1.0.11",
-                "inherits": "2.0.3"
+                "block-stream": "*",
+                "fstream": "^1.0.2",
+                "inherits": "2"
               },
               "dependencies": {
                 "block-stream": {
@@ -4225,7 +4357,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "inherits": "2.0.3"
+                    "inherits": "~2.0.0"
                   }
                 }
               }
@@ -4250,7 +4382,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "unique-slug": "2.0.0"
+                "unique-slug": "^2.0.0"
               },
               "dependencies": {
                 "unique-slug": {
@@ -4258,7 +4390,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "imurmurhash": "0.1.4"
+                    "imurmurhash": "^0.1.4"
                   }
                 }
               }
@@ -4273,14 +4405,14 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "boxen": "1.1.0",
-                "chalk": "1.1.3",
-                "configstore": "3.1.0",
-                "import-lazy": "2.1.0",
-                "is-npm": "1.0.0",
-                "latest-version": "3.1.0",
-                "semver-diff": "2.1.0",
-                "xdg-basedir": "3.0.0"
+                "boxen": "^1.0.0",
+                "chalk": "^1.0.0",
+                "configstore": "^3.0.0",
+                "import-lazy": "^2.1.0",
+                "is-npm": "^1.0.0",
+                "latest-version": "^3.0.0",
+                "semver-diff": "^2.0.0",
+                "xdg-basedir": "^3.0.0"
               },
               "dependencies": {
                 "boxen": {
@@ -4288,13 +4420,13 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "ansi-align": "2.0.0",
-                    "camelcase": "4.1.0",
-                    "chalk": "1.1.3",
-                    "cli-boxes": "1.0.0",
-                    "string-width": "2.1.0",
-                    "term-size": "0.1.1",
-                    "widest-line": "1.0.0"
+                    "ansi-align": "^2.0.0",
+                    "camelcase": "^4.0.0",
+                    "chalk": "^1.1.1",
+                    "cli-boxes": "^1.0.0",
+                    "string-width": "^2.0.0",
+                    "term-size": "^0.1.0",
+                    "widest-line": "^1.0.0"
                   },
                   "dependencies": {
                     "ansi-align": {
@@ -4302,7 +4434,7 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "string-width": "2.1.0"
+                        "string-width": "^2.0.0"
                       }
                     },
                     "camelcase": {
@@ -4320,8 +4452,8 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "is-fullwidth-code-point": "2.0.0",
-                        "strip-ansi": "4.0.0"
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^4.0.0"
                       },
                       "dependencies": {
                         "is-fullwidth-code-point": {
@@ -4334,7 +4466,7 @@
                           "bundled": true,
                           "dev": true,
                           "requires": {
-                            "ansi-regex": "3.0.0"
+                            "ansi-regex": "^3.0.0"
                           }
                         }
                       }
@@ -4344,7 +4476,7 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "execa": "0.4.0"
+                        "execa": "^0.4.0"
                       },
                       "dependencies": {
                         "execa": {
@@ -4352,12 +4484,12 @@
                           "bundled": true,
                           "dev": true,
                           "requires": {
-                            "cross-spawn-async": "2.2.5",
-                            "is-stream": "1.1.0",
-                            "npm-run-path": "1.0.0",
-                            "object-assign": "4.1.1",
-                            "path-key": "1.0.0",
-                            "strip-eof": "1.0.0"
+                            "cross-spawn-async": "^2.1.1",
+                            "is-stream": "^1.1.0",
+                            "npm-run-path": "^1.0.0",
+                            "object-assign": "^4.0.1",
+                            "path-key": "^1.0.0",
+                            "strip-eof": "^1.0.0"
                           },
                           "dependencies": {
                             "cross-spawn-async": {
@@ -4365,8 +4497,8 @@
                               "bundled": true,
                               "dev": true,
                               "requires": {
-                                "lru-cache": "4.1.1",
-                                "which": "1.2.14"
+                                "lru-cache": "^4.0.0",
+                                "which": "^1.2.8"
                               }
                             },
                             "is-stream": {
@@ -4379,7 +4511,7 @@
                               "bundled": true,
                               "dev": true,
                               "requires": {
-                                "path-key": "1.0.0"
+                                "path-key": "^1.0.0"
                               }
                             },
                             "object-assign": {
@@ -4406,7 +4538,7 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "string-width": "1.0.2"
+                        "string-width": "^1.0.1"
                       },
                       "dependencies": {
                         "string-width": {
@@ -4414,9 +4546,9 @@
                           "bundled": true,
                           "dev": true,
                           "requires": {
-                            "code-point-at": "1.1.0",
-                            "is-fullwidth-code-point": "1.0.0",
-                            "strip-ansi": "3.0.1"
+                            "code-point-at": "^1.0.0",
+                            "is-fullwidth-code-point": "^1.0.0",
+                            "strip-ansi": "^3.0.0"
                           },
                           "dependencies": {
                             "code-point-at": {
@@ -4429,7 +4561,7 @@
                               "bundled": true,
                               "dev": true,
                               "requires": {
-                                "number-is-nan": "1.0.1"
+                                "number-is-nan": "^1.0.0"
                               },
                               "dependencies": {
                                 "number-is-nan": {
@@ -4444,7 +4576,7 @@
                               "bundled": true,
                               "dev": true,
                               "requires": {
-                                "ansi-regex": "2.1.1"
+                                "ansi-regex": "^2.0.0"
                               },
                               "dependencies": {
                                 "ansi-regex": {
@@ -4465,11 +4597,11 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "ansi-styles": "2.2.1",
-                    "escape-string-regexp": "1.0.5",
-                    "has-ansi": "2.0.0",
-                    "strip-ansi": "3.0.1",
-                    "supports-color": "2.0.0"
+                    "ansi-styles": "^2.2.1",
+                    "escape-string-regexp": "^1.0.2",
+                    "has-ansi": "^2.0.0",
+                    "strip-ansi": "^3.0.0",
+                    "supports-color": "^2.0.0"
                   },
                   "dependencies": {
                     "ansi-styles": {
@@ -4487,7 +4619,7 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "ansi-regex": "2.1.1"
+                        "ansi-regex": "^2.0.0"
                       },
                       "dependencies": {
                         "ansi-regex": {
@@ -4502,7 +4634,7 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "ansi-regex": "2.1.1"
+                        "ansi-regex": "^2.0.0"
                       },
                       "dependencies": {
                         "ansi-regex": {
@@ -4524,12 +4656,12 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "dot-prop": "4.1.1",
-                    "graceful-fs": "4.1.11",
-                    "make-dir": "1.0.0",
-                    "unique-string": "1.0.0",
-                    "write-file-atomic": "2.1.0",
-                    "xdg-basedir": "3.0.0"
+                    "dot-prop": "^4.1.0",
+                    "graceful-fs": "^4.1.2",
+                    "make-dir": "^1.0.0",
+                    "unique-string": "^1.0.0",
+                    "write-file-atomic": "^2.0.0",
+                    "xdg-basedir": "^3.0.0"
                   },
                   "dependencies": {
                     "dot-prop": {
@@ -4537,7 +4669,7 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "is-obj": "1.0.1"
+                        "is-obj": "^1.0.0"
                       },
                       "dependencies": {
                         "is-obj": {
@@ -4552,7 +4684,7 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "pify": "2.3.0"
+                        "pify": "^2.3.0"
                       },
                       "dependencies": {
                         "pify": {
@@ -4567,7 +4699,7 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "crypto-random-string": "1.0.0"
+                        "crypto-random-string": "^1.0.0"
                       },
                       "dependencies": {
                         "crypto-random-string": {
@@ -4594,7 +4726,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "package-json": "4.0.1"
+                    "package-json": "^4.0.0"
                   },
                   "dependencies": {
                     "package-json": {
@@ -4602,10 +4734,10 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "got": "6.7.1",
-                        "registry-auth-token": "3.3.1",
-                        "registry-url": "3.1.0",
-                        "semver": "5.3.0"
+                        "got": "^6.7.1",
+                        "registry-auth-token": "^3.0.1",
+                        "registry-url": "^3.0.3",
+                        "semver": "^5.1.0"
                       },
                       "dependencies": {
                         "got": {
@@ -4613,17 +4745,17 @@
                           "bundled": true,
                           "dev": true,
                           "requires": {
-                            "create-error-class": "3.0.2",
-                            "duplexer3": "0.1.4",
-                            "get-stream": "3.0.0",
-                            "is-redirect": "1.0.0",
-                            "is-retry-allowed": "1.1.0",
-                            "is-stream": "1.1.0",
-                            "lowercase-keys": "1.0.0",
-                            "safe-buffer": "5.1.1",
-                            "timed-out": "4.0.1",
-                            "unzip-response": "2.0.1",
-                            "url-parse-lax": "1.0.0"
+                            "create-error-class": "^3.0.0",
+                            "duplexer3": "^0.1.4",
+                            "get-stream": "^3.0.0",
+                            "is-redirect": "^1.0.0",
+                            "is-retry-allowed": "^1.0.0",
+                            "is-stream": "^1.0.0",
+                            "lowercase-keys": "^1.0.0",
+                            "safe-buffer": "^5.0.1",
+                            "timed-out": "^4.0.0",
+                            "unzip-response": "^2.0.1",
+                            "url-parse-lax": "^1.0.0"
                           },
                           "dependencies": {
                             "create-error-class": {
@@ -4631,7 +4763,7 @@
                               "bundled": true,
                               "dev": true,
                               "requires": {
-                                "capture-stack-trace": "1.0.0"
+                                "capture-stack-trace": "^1.0.0"
                               },
                               "dependencies": {
                                 "capture-stack-trace": {
@@ -4686,7 +4818,7 @@
                               "bundled": true,
                               "dev": true,
                               "requires": {
-                                "prepend-http": "1.0.4"
+                                "prepend-http": "^1.0.1"
                               },
                               "dependencies": {
                                 "prepend-http": {
@@ -4703,8 +4835,8 @@
                           "bundled": true,
                           "dev": true,
                           "requires": {
-                            "rc": "1.2.1",
-                            "safe-buffer": "5.1.1"
+                            "rc": "^1.1.6",
+                            "safe-buffer": "^5.0.1"
                           },
                           "dependencies": {
                             "rc": {
@@ -4712,10 +4844,10 @@
                               "bundled": true,
                               "dev": true,
                               "requires": {
-                                "deep-extend": "0.4.2",
-                                "ini": "1.3.4",
-                                "minimist": "1.2.0",
-                                "strip-json-comments": "2.0.1"
+                                "deep-extend": "~0.4.0",
+                                "ini": "~1.3.0",
+                                "minimist": "^1.2.0",
+                                "strip-json-comments": "~2.0.1"
                               },
                               "dependencies": {
                                 "deep-extend": {
@@ -4742,7 +4874,7 @@
                           "bundled": true,
                           "dev": true,
                           "requires": {
-                            "rc": "1.2.1"
+                            "rc": "^1.0.1"
                           },
                           "dependencies": {
                             "rc": {
@@ -4750,10 +4882,10 @@
                               "bundled": true,
                               "dev": true,
                               "requires": {
-                                "deep-extend": "0.4.2",
-                                "ini": "1.3.4",
-                                "minimist": "1.2.0",
-                                "strip-json-comments": "2.0.1"
+                                "deep-extend": "~0.4.0",
+                                "ini": "~1.3.0",
+                                "minimist": "^1.2.0",
+                                "strip-json-comments": "~2.0.1"
                               },
                               "dependencies": {
                                 "deep-extend": {
@@ -4784,7 +4916,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "semver": "5.3.0"
+                    "semver": "^5.0.3"
                   }
                 },
                 "xdg-basedir": {
@@ -4804,8 +4936,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "spdx-correct": "1.0.2",
-                "spdx-expression-parse": "1.0.4"
+                "spdx-correct": "~1.0.0",
+                "spdx-expression-parse": "~1.0.0"
               },
               "dependencies": {
                 "spdx-correct": {
@@ -4813,7 +4945,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "spdx-license-ids": "1.2.2"
+                    "spdx-license-ids": "^1.0.2"
                   },
                   "dependencies": {
                     "spdx-license-ids": {
@@ -4835,7 +4967,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "builtins": "1.0.3"
+                "builtins": "^1.0.3"
               },
               "dependencies": {
                 "builtins": {
@@ -4850,7 +4982,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "isexe": "2.0.0"
+                "isexe": "^2.0.0"
               },
               "dependencies": {
                 "isexe": {
@@ -4865,8 +4997,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "errno": "0.1.4",
-                "xtend": "4.0.1"
+                "errno": ">=0.1.1 <0.2.0-0",
+                "xtend": ">=4.0.0 <4.1.0-0"
               },
               "dependencies": {
                 "errno": {
@@ -4874,7 +5006,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "prr": "0.0.0"
+                    "prr": "~0.0.0"
                   },
                   "dependencies": {
                     "prr": {
@@ -4901,9 +5033,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "graceful-fs": "4.1.11",
-                "imurmurhash": "0.1.4",
-                "slide": "1.1.6"
+                "graceful-fs": "^4.1.11",
+                "imurmurhash": "^0.1.4",
+                "slide": "^1.1.5"
               }
             }
           }
@@ -4913,10 +5045,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "hosted-git-info": "2.6.0",
-            "osenv": "0.1.5",
-            "semver": "5.5.0",
-            "validate-npm-package-name": "3.0.0"
+            "hosted-git-info": "^2.6.0",
+            "osenv": "^0.1.5",
+            "semver": "^5.5.0",
+            "validate-npm-package-name": "^3.0.0"
           }
         },
         "npm-run-path": {
@@ -4924,7 +5056,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "path-key": "2.0.1"
+            "path-key": "^2.0.0"
           }
         },
         "number-is-nan": {
@@ -4937,7 +5069,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "1"
           }
         },
         "os-homedir": {
@@ -4950,9 +5082,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "execa": "0.7.0",
-            "lcid": "1.0.0",
-            "mem": "1.1.0"
+            "execa": "^0.7.0",
+            "lcid": "^1.0.0",
+            "mem": "^1.1.0"
           }
         },
         "os-tmpdir": {
@@ -4965,8 +5097,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
           }
         },
         "p-finally": {
@@ -4979,7 +5111,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "p-try": "1.0.0"
+            "p-try": "^1.0.0"
           }
         },
         "p-locate": {
@@ -4987,7 +5119,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "p-limit": "1.2.0"
+            "p-limit": "^1.1.0"
           }
         },
         "p-try": {
@@ -5000,10 +5132,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "got": "6.7.1",
-            "registry-auth-token": "3.3.2",
-            "registry-url": "3.1.0",
-            "semver": "5.5.0"
+            "got": "^6.7.1",
+            "registry-auth-token": "^3.0.1",
+            "registry-url": "^3.0.3",
+            "semver": "^5.1.0"
           }
         },
         "path-exists": {
@@ -5046,10 +5178,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "deep-extend": "0.4.2",
-            "ini": "1.3.5",
-            "minimist": "1.2.0",
-            "strip-json-comments": "2.0.1"
+            "deep-extend": "~0.4.0",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
           }
         },
         "registry-auth-token": {
@@ -5057,8 +5189,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "rc": "1.2.6",
-            "safe-buffer": "5.1.1"
+            "rc": "^1.1.6",
+            "safe-buffer": "^5.0.1"
           }
         },
         "registry-url": {
@@ -5066,7 +5198,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "rc": "1.2.6"
+            "rc": "^1.0.1"
           }
         },
         "require-directory": {
@@ -5084,7 +5216,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "glob": "7.1.2"
+            "glob": "^7.0.5"
           }
         },
         "safe-buffer": {
@@ -5102,7 +5234,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "semver": "5.5.0"
+            "semver": "^5.0.3"
           }
         },
         "set-blocking": {
@@ -5115,7 +5247,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "shebang-regex": "1.0.0"
+            "shebang-regex": "^1.0.0"
           }
         },
         "shebang-regex": {
@@ -5133,8 +5265,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           }
         },
         "strip-ansi": {
@@ -5142,7 +5274,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         },
         "strip-eof": {
@@ -5160,7 +5292,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         },
         "term-size": {
@@ -5168,7 +5300,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "execa": "0.7.0"
+            "execa": "^0.7.0"
           }
         },
         "timed-out": {
@@ -5181,7 +5313,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "crypto-random-string": "1.0.0"
+            "crypto-random-string": "^1.0.0"
           }
         },
         "unzip-response": {
@@ -5194,16 +5326,16 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "boxen": "1.3.0",
-            "chalk": "2.3.2",
-            "configstore": "3.1.2",
-            "import-lazy": "2.1.0",
-            "is-ci": "1.1.0",
-            "is-installed-globally": "0.1.0",
-            "is-npm": "1.0.0",
-            "latest-version": "3.1.0",
-            "semver-diff": "2.1.0",
-            "xdg-basedir": "3.0.0"
+            "boxen": "^1.2.1",
+            "chalk": "^2.0.1",
+            "configstore": "^3.0.0",
+            "import-lazy": "^2.1.0",
+            "is-ci": "^1.0.10",
+            "is-installed-globally": "^0.1.0",
+            "is-npm": "^1.0.0",
+            "latest-version": "^3.0.0",
+            "semver-diff": "^2.0.0",
+            "xdg-basedir": "^3.0.0"
           }
         },
         "url-parse-lax": {
@@ -5211,7 +5343,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "prepend-http": "1.0.4"
+            "prepend-http": "^1.0.1"
           }
         },
         "validate-npm-package-name": {
@@ -5219,7 +5351,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "builtins": "1.0.3"
+            "builtins": "^1.0.3"
           }
         },
         "which": {
@@ -5227,7 +5359,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "isexe": "2.0.0"
+            "isexe": "^2.0.0"
           }
         },
         "which-module": {
@@ -5240,7 +5372,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "string-width": "2.1.1"
+            "string-width": "^2.1.1"
           }
         },
         "wrap-ansi": {
@@ -5248,8 +5380,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1"
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1"
           },
           "dependencies": {
             "ansi-regex": {
@@ -5262,7 +5394,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "number-is-nan": "1.0.1"
+                "number-is-nan": "^1.0.0"
               }
             },
             "string-width": {
@@ -5270,9 +5402,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
               }
             },
             "strip-ansi": {
@@ -5280,7 +5412,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "ansi-regex": "2.1.1"
+                "ansi-regex": "^2.0.0"
               }
             }
           }
@@ -5295,9 +5427,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "imurmurhash": "0.1.4",
-            "signal-exit": "3.0.2"
+            "graceful-fs": "^4.1.11",
+            "imurmurhash": "^0.1.4",
+            "signal-exit": "^3.0.2"
           }
         },
         "xdg-basedir": {
@@ -5320,18 +5452,18 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "cliui": "4.0.0",
-            "decamelize": "1.2.0",
-            "find-up": "2.1.0",
-            "get-caller-file": "1.0.2",
-            "os-locale": "2.1.0",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "2.1.1",
-            "which-module": "2.0.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "9.0.2"
+            "cliui": "^4.0.0",
+            "decamelize": "^1.1.1",
+            "find-up": "^2.1.0",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^2.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^9.0.2"
           },
           "dependencies": {
             "y18n": {
@@ -5346,7 +5478,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "camelcase": "4.1.0"
+            "camelcase": "^4.1.0"
           }
         }
       }
@@ -5371,12 +5503,12 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "onetime": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
       "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
     },
     "opener": {
@@ -5389,10 +5521,10 @@
       "resolved": "https://registry.npmjs.org/ora/-/ora-0.2.3.tgz",
       "integrity": "sha1-N1J9Igrc1Tw5tzVx11QVbV22V6Q=",
       "requires": {
-        "chalk": "1.1.3",
-        "cli-cursor": "1.0.2",
-        "cli-spinners": "0.1.2",
-        "object-assign": "4.1.1"
+        "chalk": "^1.1.1",
+        "cli-cursor": "^1.0.2",
+        "cli-spinners": "^0.1.2",
+        "object-assign": "^4.0.1"
       },
       "dependencies": {
         "chalk": {
@@ -5400,11 +5532,11 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
         "supports-color": {
@@ -5422,11 +5554,11 @@
     "os-locale": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-      "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+      "integrity": "sha1-QrwpAKa1uL0XN2yOiCtlr8zyS/I=",
       "requires": {
-        "execa": "0.7.0",
-        "lcid": "1.0.0",
-        "mem": "1.1.0"
+        "execa": "^0.7.0",
+        "lcid": "^1.0.0",
+        "mem": "^1.1.0"
       },
       "dependencies": {
         "cross-spawn": {
@@ -5434,9 +5566,9 @@
           "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
           "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
           "requires": {
-            "lru-cache": "4.1.5",
-            "shebang-command": "1.2.0",
-            "which": "1.3.1"
+            "lru-cache": "^4.0.1",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
           }
         },
         "execa": {
@@ -5444,13 +5576,13 @@
           "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
           "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
           "requires": {
-            "cross-spawn": "5.1.0",
-            "get-stream": "3.0.0",
-            "is-stream": "1.1.0",
-            "npm-run-path": "2.0.2",
-            "p-finally": "1.0.0",
-            "signal-exit": "3.0.2",
-            "strip-eof": "1.0.0"
+            "cross-spawn": "^5.0.1",
+            "get-stream": "^3.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
           }
         }
       }
@@ -5473,9 +5605,9 @@
     "p-limit": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+      "integrity": "sha1-uGvV8MJWkJEcdZD8v8IBDVSzzLg=",
       "requires": {
-        "p-try": "1.0.0"
+        "p-try": "^1.0.0"
       }
     },
     "p-locate": {
@@ -5483,13 +5615,13 @@
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "requires": {
-        "p-limit": "1.3.0"
+        "p-limit": "^1.1.0"
       }
     },
     "p-map": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
-      "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA=="
+      "integrity": "sha1-5OlPMR6rvIYzoeeZCBZfyiYkG2s="
     },
     "p-try": {
       "version": "1.0.0",
@@ -5531,6 +5663,37 @@
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
     },
+    "pretty-format": {
+      "version": "24.9.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.9.0.tgz",
+      "integrity": "sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==",
+      "requires": {
+        "@jest/types": "^24.9.0",
+        "ansi-regex": "^4.0.0",
+        "ansi-styles": "^3.2.0",
+        "react-is": "^16.8.4"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "react-is": {
+          "version": "16.9.0",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.9.0.tgz",
+          "integrity": "sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw=="
+        }
+      }
+    },
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -5541,9 +5704,9 @@
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
       "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
       "requires": {
-        "loose-envify": "1.4.0",
-        "object-assign": "4.1.1",
-        "react-is": "16.8.2"
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.8.1"
       }
     },
     "pseudomap": {
@@ -5559,10 +5722,10 @@
     "pump": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "integrity": "sha1-tKIRaBW94vTh6mAjVOjHVWUQemQ=",
       "requires": {
-        "end-of-stream": "1.4.1",
-        "once": "1.4.0"
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "punycode": {
@@ -5573,7 +5736,7 @@
     "qs": {
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+      "integrity": "sha1-yzroBuh0BERYTvFUzo7pjUA/PjY="
     },
     "querystring": {
       "version": "0.2.0",
@@ -5590,10 +5753,10 @@
       "resolved": "https://registry.npmjs.org/react/-/react-16.8.2.tgz",
       "integrity": "sha512-aB2ctx9uQ9vo09HVknqv3DGRpI7OIGJhCx3Bt0QqoRluEjHSaObJl+nG12GDdYH6sTgE7YiPJ6ZUyMx9kICdXw==",
       "requires": {
-        "loose-envify": "1.4.0",
-        "object-assign": "4.1.1",
-        "prop-types": "15.7.2",
-        "scheduler": "0.13.2"
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2",
+        "scheduler": "^0.13.2"
       }
     },
     "react-dom": {
@@ -5601,10 +5764,10 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.8.2.tgz",
       "integrity": "sha512-cPGfgFfwi+VCZjk73buu14pYkYBR1b/SRMSYqkLDdhSEHnSwcuYTPu6/Bh6ZphJFIk80XLvbSe2azfcRzNF+Xg==",
       "requires": {
-        "loose-envify": "1.4.0",
-        "object-assign": "4.1.1",
-        "prop-types": "15.7.2",
-        "scheduler": "0.13.2"
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2",
+        "scheduler": "^0.13.2"
       }
     },
     "react-is": {
@@ -5615,28 +5778,28 @@
     "readable-stream": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+      "integrity": "sha1-sRwn2IuP8fvgcGQ8+UsMea4bCq8=",
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "2.0.1",
-        "safe-buffer": "5.1.2",
-        "string_decoder": "1.1.1",
-        "util-deprecate": "1.0.2"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
       }
     },
     "regenerator-runtime": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+      "integrity": "sha1-vgWtf5v30i4Fb5cmzuUBf78Z4uk="
     },
     "repeating": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "requires": {
-        "is-finite": "1.0.2"
+        "is-finite": "^1.0.0"
       }
     },
     "request": {
@@ -5644,26 +5807,26 @@
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
       "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
       "requires": {
-        "aws-sign2": "0.7.0",
-        "aws4": "1.8.0",
-        "caseless": "0.12.0",
-        "combined-stream": "1.0.8",
-        "extend": "3.0.2",
-        "forever-agent": "0.6.1",
-        "form-data": "2.3.3",
-        "har-validator": "5.1.3",
-        "http-signature": "1.2.0",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.24",
-        "oauth-sign": "0.9.0",
-        "performance-now": "2.1.0",
-        "qs": "6.5.2",
-        "safe-buffer": "5.1.2",
-        "tough-cookie": "2.4.3",
-        "tunnel-agent": "0.6.0",
-        "uuid": "3.3.2"
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.0",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.4.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
       }
     },
     "request-progress": {
@@ -5671,8 +5834,8 @@
       "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-0.4.0.tgz",
       "integrity": "sha1-wZVOOQhqqFJpxWYLzuAUKmpw1+c=",
       "requires": {
-        "node-eta": "0.1.1",
-        "throttleit": "0.0.2"
+        "node-eta": "^0.1.1",
+        "throttleit": "^0.0.2"
       }
     },
     "require-directory": {
@@ -5690,8 +5853,8 @@
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
       "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
       "requires": {
-        "exit-hook": "1.1.1",
-        "onetime": "1.1.0"
+        "exit-hook": "^1.0.0",
+        "onetime": "^1.0.0"
       }
     },
     "rimraf": {
@@ -5699,7 +5862,7 @@
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
       "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
       "requires": {
-        "glob": "7.1.4"
+        "glob": "^7.1.3"
       },
       "dependencies": {
         "glob": {
@@ -5707,12 +5870,12 @@
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
           "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         }
       }
@@ -5720,7 +5883,7 @@
     "rxjs": {
       "version": "5.5.12",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.12.tgz",
-      "integrity": "sha1-b6YbinfD15PbrycL7i9D9lLXQcw=",
+      "integrity": "sha512-xx2itnL5sBbqeeiVgNPVuQQ1nC8Jp2WfNJhXWHmElW9YmrpS9UVnNzhP3EH3HFqexO5Tlp8GhYY+WEcqcVMvGw==",
       "requires": {
         "symbol-observable": "1.0.1"
       }
@@ -5728,20 +5891,20 @@
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0="
     },
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+      "integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo="
     },
     "scheduler": {
       "version": "0.13.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.2.tgz",
       "integrity": "sha512-qK5P8tHS7vdEMCW5IPyt8v9MJOHqTrOUgPXib7tqm9vh834ibBX5BNhwkplX/0iOzHW5sXyluehYfS9yrkz9+w==",
       "requires": {
-        "loose-envify": "1.4.0",
-        "object-assign": "4.1.1"
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
       }
     },
     "semver": {
@@ -5759,7 +5922,7 @@
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "requires": {
-        "shebang-regex": "1.0.0"
+        "shebang-regex": "^1.0.0"
       }
     },
     "shebang-regex": {
@@ -5780,17 +5943,17 @@
     "sshpk": {
       "version": "1.16.1",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
-      "integrity": "sha1-+2YcC+8ps520B2nuOfpwCT1vaHc=",
+      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
       "requires": {
-        "asn1": "0.2.4",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.2",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.2",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.1",
-        "safer-buffer": "2.1.2",
-        "tweetnacl": "0.14.5"
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
       }
     },
     "stream-to-observable": {
@@ -5798,22 +5961,22 @@
       "resolved": "https://registry.npmjs.org/stream-to-observable/-/stream-to-observable-0.1.0.tgz",
       "integrity": "sha1-Rb8dny19wJvtgfHDB8Qw5ouEz/4="
     },
-    "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "requires": {
-        "safe-buffer": "5.1.2"
-      }
-    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "requires": {
-        "code-point-at": "1.1.0",
-        "is-fullwidth-code-point": "1.0.0",
-        "strip-ansi": "3.0.1"
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
+      }
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
+      "requires": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "strip-ansi": {
@@ -5821,7 +5984,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "strip-eof": {
@@ -5834,7 +5997,7 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "requires": {
-        "has-flag": "3.0.0"
+        "has-flag": "^3.0.0"
       }
     },
     "symbol-observable": {
@@ -5850,9 +6013,9 @@
     "tcomb-validation": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/tcomb-validation/-/tcomb-validation-3.4.1.tgz",
-      "integrity": "sha512-urVVMQOma4RXwiVCa2nM2eqrAomHROHvWPuj6UkDGz/eb5kcy0x6P0dVt6kzpUZtYMNoAqJLWmz1BPtxrtjtrA==",
+      "integrity": "sha1-p2luwXbOVqCB2eAZ+LcypaiJS2U=",
       "requires": {
-        "tcomb": "3.2.29"
+        "tcomb": "^3.0.0"
       }
     },
     "throttleit": {
@@ -5865,7 +6028,7 @@
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.1.0.tgz",
       "integrity": "sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==",
       "requires": {
-        "rimraf": "2.6.3"
+        "rimraf": "^2.6.3"
       }
     },
     "tough-cookie": {
@@ -5873,8 +6036,8 @@
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
       "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
       "requires": {
-        "psl": "1.1.33",
-        "punycode": "1.4.1"
+        "psl": "^1.1.24",
+        "punycode": "^1.4.1"
       },
       "dependencies": {
         "punycode": {
@@ -5889,7 +6052,7 @@
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "requires": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "^5.0.1"
       }
     },
     "tweetnacl": {
@@ -5905,14 +6068,14 @@
     "universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+      "integrity": "sha1-tkb2m+OULavOzJ1mOcgNwQXvqmY="
     },
     "uri-js": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
       "requires": {
-        "punycode": "2.1.1"
+        "punycode": "^2.1.0"
       }
     },
     "url": {
@@ -5939,29 +6102,34 @@
     "uuid": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+      "integrity": "sha1-G0r0lV6zB3xQHCOHL8ZROBFYcTE="
     },
     "validator": {
       "version": "9.4.1",
       "resolved": "https://registry.npmjs.org/validator/-/validator-9.4.1.tgz",
-      "integrity": "sha512-YV5KjzvRmSyJ1ee/Dm5UED0G+1L4GZnLN3w6/T+zZm8scVua4sOhYKWTUrKa0H/tMiJyO9QLHMPN+9mB/aMunA=="
+      "integrity": "sha1-q/Rm05i1Yc0kMFARLG/x3mzBJmM="
     },
     "verror": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "requires": {
-        "assert-plus": "1.0.0",
+        "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "1.3.0"
+        "extsprintf": "^1.2.0"
       }
+    },
+    "wait-for-expect": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/wait-for-expect/-/wait-for-expect-1.3.0.tgz",
+      "integrity": "sha512-8fJU7jiA96HfGPt+P/UilelSAZfhMBJ52YhKzlmZQvKEZU2EcD1GQ0yqGB6liLdHjYtYAoGVigYwdxr5rktvzA=="
     },
     "which": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "integrity": "sha1-pFBD1U9YBTFtqNYvn1CRjT2nCwo=",
       "requires": {
-        "isexe": "2.0.0"
+        "isexe": "^2.0.0"
       }
     },
     "which-module": {
@@ -5974,8 +6142,8 @@
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "requires": {
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1"
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1"
       }
     },
     "wrappy": {
@@ -5996,20 +6164,20 @@
     "yargs": {
       "version": "10.1.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-10.1.2.tgz",
-      "integrity": "sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==",
+      "integrity": "sha1-RU0HTCsWpRpD4vt4B+T53mnMtcU=",
       "requires": {
-        "cliui": "4.1.0",
-        "decamelize": "1.2.0",
-        "find-up": "2.1.0",
-        "get-caller-file": "1.0.3",
-        "os-locale": "2.1.0",
-        "require-directory": "2.1.1",
-        "require-main-filename": "1.0.1",
-        "set-blocking": "2.0.0",
-        "string-width": "2.1.1",
-        "which-module": "2.0.0",
-        "y18n": "3.2.1",
-        "yargs-parser": "8.1.0"
+        "cliui": "^4.0.0",
+        "decamelize": "^1.1.1",
+        "find-up": "^2.1.0",
+        "get-caller-file": "^1.0.1",
+        "os-locale": "^2.0.0",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^1.0.1",
+        "set-blocking": "^2.0.0",
+        "string-width": "^2.0.0",
+        "which-module": "^2.0.0",
+        "y18n": "^3.2.1",
+        "yargs-parser": "^8.1.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -6025,10 +6193,10 @@
         "string-width": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           }
         },
         "strip-ansi": {
@@ -6036,7 +6204,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -6044,9 +6212,9 @@
     "yargs-parser": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.1.0.tgz",
-      "integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
+      "integrity": "sha1-8TdqM7Ziml0GN4KUTacyYx6WaVA=",
       "requires": {
-        "camelcase": "4.1.0"
+        "camelcase": "^4.1.0"
       }
     },
     "yauzl": {
@@ -6054,8 +6222,8 @@
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
       "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
       "requires": {
-        "buffer-crc32": "0.2.13",
-        "fd-slicer": "1.1.0"
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
       },
       "dependencies": {
         "fd-slicer": {
@@ -6063,7 +6231,7 @@
           "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
           "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
           "requires": {
-            "pend": "1.2.0"
+            "pend": "~1.2.0"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "homepage": "https://github.com/USSBA/sba-gov-integration-tests#readme",
   "dependencies": {
+    "@testing-library/cypress": "^5.0.0",
     "cypress": "^3.3.2",
     "mocha": "^5.2.0",
     "mochawesome": "^3.1.1",


### PR DESCRIPTION
Adding the DOM Testing library commands to cypress so that we can use the `*byTestId` functions to easily find `data-testid` elements.  Refactored the district offices tests to use this.